### PR TITLE
feat: restructure rooms — #general + #workshop

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -9,20 +9,12 @@
     { "id": "ruantang", "name": "Ruantang", "avatar": "🍮" }
   ],
   "rooms": [
-    { "id": "product", "name": "#product", "agents": [
-      { "id": "kagura", "requireMention": false },
-      { "id": "anan", "requireMention": true }
-    ]},
-    { "id": "dev", "name": "#dev", "agents": [
-      { "id": "kagura", "requireMention": false },
-      { "id": "ruantang", "requireMention": true }
-    ]},
-    { "id": "war-room", "name": "#war-room", "agents": [
+    { "id": "general", "name": "#general", "agents": [
       { "id": "kagura", "requireMention": false },
       { "id": "anan", "requireMention": true },
       { "id": "ruantang", "requireMention": true }
     ]},
-    { "id": "workshop-dev", "name": "#workshop-dev", "agents": [
+    { "id": "workshop", "name": "#workshop", "agents": [
       { "id": "kagura", "requireMention": false }
     ]}
   ]


### PR DESCRIPTION
Replaces old room structure (#product, #dev, #war-room, #workshop-dev) with:

- **#general** — daily chat, Kagura + Anan + Ruantang
- **#workshop** — Workshop product discussion, Kagura only (for now)

Task-specific channels will be created dynamically as needed (e.g. #workshop-typing when implementing a feature).

This aligns with real company channel structure: #general is the water cooler, product channels are focused discussion spaces.