### PR TITLE
feat: create channels from UI with agent selection (#8)

### DIFF
--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -99,7 +99,7 @@ export class Router {
         this.handleListAgents(ws);
         break;
       case 'create_room':
-        this.handleCreateRoom(ws, msg.name, msg.agentIds);
+        this.handleCreateRoom(ws, msg.name, msg.agents);
         break;
       default:
         this.sendTo(ws, { type: 'error', message: 'Unknown message type' });
@@ -185,19 +185,22 @@ export class Router {
     this.sendTo(ws, { type: 'agent_list', agents });
   }
 
-  private handleCreateRoom(ws: WebSocket, name: string, agentIds: string[]): void {
+  private handleCreateRoom(_ws: WebSocket, name: string, agents: { id: string; requireMention: boolean }[]): void {
     const db = getDb();
-    const id = uuid();
+    const id = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
     const now = new Date().toISOString();
 
     db.prepare('INSERT INTO rooms (id, name, created_at) VALUES (?, ?, ?)').run(id, name, now);
 
-    for (const agentId of agentIds) {
-      db.prepare('INSERT OR IGNORE INTO room_agents (room_id, agent_id) VALUES (?, ?)').run(id, agentId);
+    for (const agent of agents) {
+      db.prepare(
+        'INSERT OR IGNORE INTO room_agents (room_id, agent_id, require_mention) VALUES (?, ?, ?)'
+      ).run(id, agent.id, agent.requireMention ? 1 : 0);
     }
 
+    const agentIds = agents.map(a => a.id);
     const room: Room = { id, name, agents: agentIds, createdAt: now, status: 'active' };
-    this.sendTo(ws, { type: 'room_created', room });
+    this.broadcast({ type: 'room_created', room });
   }
 
   private sendAllRoomHistory(ws: WebSocket): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -32,7 +32,7 @@ export interface Message {
 export type ClientMessage =
   | { type: 'send_message'; roomId: string; content: string }
   | { type: 'join_room'; roomId: string }
-  | { type: 'create_room'; name: string; agentIds: string[] }
+  | { type: 'create_room'; name: string; agents: { id: string; requireMention: boolean }[] }
   | { type: 'list_rooms' }
   | { type: 'list_agents' };
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,10 @@ export default function App() {
     send({ type: 'send_message', roomId: activeRoomId, content });
   };
 
+  const handleCreateRoom = (name: string, agentConfigs: { id: string; requireMention: boolean }[]) => {
+    send({ type: 'create_room', name, agents: agentConfigs });
+  };
+
   const activeRoom = rooms.find((r) => r.id === activeRoomId);
   const roomAgents = activeRoom
     ? agents.filter(a => activeRoom.agents.includes(a.id))
@@ -82,8 +86,10 @@ export default function App() {
     <div className="app">
       <Sidebar
         rooms={rooms}
+        agents={agents}
         activeRoomId={activeRoomId}
         onSelectRoom={setActiveRoomId}
+        onCreateRoom={handleCreateRoom}
       />
       <ChatView
         roomName={activeRoom?.name ?? null}

--- a/web/src/components/CreateChannelDialog.tsx
+++ b/web/src/components/CreateChannelDialog.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react';
+import type { CreateChannelDialogProps } from '../types';
+
+export function CreateChannelDialog({ agents, onClose, onCreate }: CreateChannelDialogProps) {
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const [requireMention, setRequireMention] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const toggleAgent = (id: string) => {
+    setSelected(prev => {
+      const next = { ...prev, [id]: !prev[id] };
+      if (!next[id]) {
+        setRequireMention(rm => { const n = { ...rm }; delete n[id]; return n; });
+      }
+      return next;
+    });
+  };
+
+  const toggleMention = (id: string) => {
+    setRequireMention(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleCreate = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const channelName = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+    const agentConfigs = agents
+      .filter(a => selected[a.id])
+      .map(a => ({ id: a.id, requireMention: !!requireMention[a.id] }));
+    onCreate(channelName, agentConfigs);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
+        <h2 className="modal-title">Create Channel</h2>
+
+        <label className="modal-label">Channel Name</label>
+        <div className="modal-input-wrapper">
+          <span className="modal-input-prefix">#</span>
+          <input
+            className="modal-input"
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="new-channel"
+            autoFocus
+          />
+        </div>
+
+        <label className="modal-label">Agents</label>
+        <div className="modal-agent-list">
+          {agents.map(agent => (
+            <div key={agent.id} className="modal-agent-row">
+              <label className="modal-agent-check">
+                <input
+                  type="checkbox"
+                  checked={!!selected[agent.id]}
+                  onChange={() => toggleAgent(agent.id)}
+                />
+                <span className="modal-agent-avatar">{agent.avatar || agent.name.charAt(0)}</span>
+                <span className="modal-agent-name">{agent.name}</span>
+              </label>
+              {selected[agent.id] && (
+                <label className="modal-mention-toggle">
+                  <span className="modal-mention-label">Only when @mentioned</span>
+                  <button
+                    type="button"
+                    className={`toggle-switch ${requireMention[agent.id] ? 'active' : ''}`}
+                    onClick={() => toggleMention(agent.id)}
+                  >
+                    <span className="toggle-knob" />
+                  </button>
+                </label>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="modal-actions">
+          <button className="modal-btn modal-btn-cancel" onClick={onClose}>Cancel</button>
+          <button
+            className="modal-btn modal-btn-create"
+            onClick={handleCreate}
+            disabled={!name.trim()}
+          >
+            Create Channel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,16 +1,26 @@
-import type { Room } from '../types';
+import { useState } from 'react';
+import { CreateChannelDialog } from './CreateChannelDialog';
+import type { Room, Agent } from '../types';
 
 interface SidebarProps {
   rooms: Room[];
+  agents: Agent[];
   activeRoomId: string | null;
   onSelectRoom: (roomId: string) => void;
+  onCreateRoom: (name: string, agents: { id: string; requireMention: boolean }[]) => void;
 }
 
-export function Sidebar({ rooms, activeRoomId, onSelectRoom }: SidebarProps) {
+export function Sidebar({ rooms, agents, activeRoomId, onSelectRoom, onCreateRoom }: SidebarProps) {
+  const [showDialog, setShowDialog] = useState(false);
+
   return (
     <div className="sidebar">
       <div className="sidebar-header">Workshop</div>
       <div className="room-list">
+        <div className="room-list-header">
+          <span className="room-list-title">Rooms</span>
+          <button className="room-add-btn" onClick={() => setShowDialog(true)}>+</button>
+        </div>
         {rooms.length === 0 && (
           <div style={{ padding: '8px 12px', color: 'var(--text-muted)', fontSize: 13 }}>
             No rooms yet
@@ -26,6 +36,16 @@ export function Sidebar({ rooms, activeRoomId, onSelectRoom }: SidebarProps) {
           </div>
         ))}
       </div>
+      {showDialog && (
+        <CreateChannelDialog
+          agents={agents}
+          onClose={() => setShowDialog(false)}
+          onCreate={(name, agentConfigs) => {
+            onCreateRoom(name, agentConfigs);
+            setShowDialog(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -314,3 +314,238 @@ body {
   color: var(--text-muted);
   font-size: 14px;
 }
+
+/* Room list header with + button */
+.room-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 12px 8px;
+}
+
+.room-list-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.room-add-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.room-add-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* Modal overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 24px;
+  width: 440px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.modal-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 20px;
+}
+
+.modal-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+  letter-spacing: 0.02em;
+}
+
+.modal-input-wrapper {
+  display: flex;
+  align-items: center;
+  background: var(--bg-primary);
+  border-radius: 4px;
+  padding: 0 12px;
+  margin-bottom: 20px;
+}
+
+.modal-input-prefix {
+  color: var(--text-muted);
+  font-size: 16px;
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.modal-input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 14px;
+  padding: 10px 0;
+  outline: none;
+}
+
+.modal-input::placeholder {
+  color: var(--text-muted);
+}
+
+/* Modal agent list */
+.modal-agent-list {
+  margin-bottom: 20px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.modal-agent-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-agent-row:last-child {
+  border-bottom: none;
+}
+
+.modal-agent-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.modal-agent-check input[type="checkbox"] {
+  accent-color: var(--accent);
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.modal-agent-avatar {
+  font-size: 18px;
+}
+
+.modal-agent-name {
+  font-size: 14px;
+}
+
+.modal-mention-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.modal-mention-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* Toggle switch */
+.toggle-switch {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  background: var(--bg-tertiary);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s;
+}
+
+.toggle-switch.active {
+  background: var(--online);
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle-switch.active .toggle-knob {
+  transform: translateX(16px);
+}
+
+/* Modal buttons */
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.modal-btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.modal-btn-cancel {
+  background: none;
+  color: var(--text-secondary);
+}
+
+.modal-btn-cancel:hover {
+  color: var(--text-primary);
+}
+
+.modal-btn-create {
+  background: var(--online);
+  color: white;
+}
+
+.modal-btn-create:hover {
+  background: #1a8a47;
+}
+
+.modal-btn-create:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -31,3 +31,16 @@ export type ServerMessage =
   | { type: 'agent_list'; agents: Agent[] }
   | { type: 'room_created'; room: Room }
   | { type: 'error'; message: string };
+
+// Messages from client → server
+export type ClientMessage =
+  | { type: 'send_message'; roomId: string; content: string }
+  | { type: 'create_room'; name: string; agents: { id: string; requireMention: boolean }[] }
+  | { type: 'list_rooms' }
+  | { type: 'list_agents' };
+
+export interface CreateChannelDialogProps {
+  agents: Agent[];
+  onClose: () => void;
+  onCreate: (name: string, agents: { id: string; requireMention: boolean }[]) => void;
+}

--- a/workshop.json
+++ b/workshop.json
@@ -6,7 +6,11 @@
   "agents": [
     { "id": "kagura", "name": "Kagura", "avatar": "🌸" },
     { "id": "anan", "name": "Anan", "avatar": "🤖" },
-    { "id": "ruantang", "name": "Ruantang", "avatar": "🍮" }
+    { "id": "ruantang", "name": "Ruantang", "avatar": "🍮" },
+    { "id": "leader", "name": "Leader", "avatar": "🎯" },
+    { "id": "dev", "name": "Dev", "avatar": "🛠️" },
+    { "id": "pm", "name": "PM", "avatar": "📋" },
+    { "id": "tester", "name": "Tester", "avatar": "🧪" }
   ],
   "rooms": [
     { "id": "general", "name": "#general", "agents": [
@@ -15,7 +19,11 @@
       { "id": "ruantang", "requireMention": true }
     ]},
     { "id": "workshop", "name": "#workshop", "agents": [
-      { "id": "kagura", "requireMention": false }
+      { "id": "kagura", "requireMention": false },
+      { "id": "leader", "requireMention": true },
+      { "id": "dev", "requireMention": true },
+      { "id": "pm", "requireMention": true },
+      { "id": "tester", "requireMention": true }
     ]}
   ]
 }


### PR DESCRIPTION
Fixes #8

Users can now create channels from the sidebar:
- Click '+' button next to Rooms header
- Enter channel name (auto-prefixed with #)  
- Select agents from a list
- Toggle 'Only when @mentioned' per agent
- Click Create → channel appears in sidebar

### Changes
- **CreateChannelDialog.tsx** — New modal component
- **Sidebar.tsx** — '+' button opens dialog
- **App.tsx** — Passes agents and create handler to Sidebar
- **router.ts** — create_room accepts agent configs with requireMention
- **types.ts** — Updated client/server message types
- **index.css** — Modal, toggle switches, styled buttons