### PR TITLE
feat(v0.3): Phase 3 — Pin sync expansion (custom pins + message pinning)

### DIFF
--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -160,6 +160,15 @@ export class Router {
       case 'pin_list':
         this.handlePinList(ws, msg.channelId);
         break;
+      case 'pin_create':
+        this.handlePinCreate(msg.channelId, msg.content, msg.label);
+        break;
+      case 'pin_message':
+        this.handlePinMessage(msg.channelId, msg.messageId);
+        break;
+      case 'pin_delete':
+        this.handlePinDelete(msg.pinId);
+        break;
       case 'patrol_config_get':
         this.handlePatrolConfigGet(ws);
         break;
@@ -546,6 +555,47 @@ export class Router {
     const rows = db.prepare('SELECT * FROM pins WHERE channel_id = ? ORDER BY updated_at DESC').all(channelId) as any[];
     const pins: Pin[] = rows.map(this.mapPinRow);
     this.sendTo(ws, { type: 'pin_list', channelId, pins });
+  }
+
+  private handlePinCreate(channelId: string, content: string, label?: string): void {
+    const db = getDb();
+    const id = uuid();
+    const now = new Date().toISOString();
+    const sourceId = label || 'custom';
+
+    db.prepare(
+      'INSERT INTO pins (id, channel_id, type, source_id, content, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, channelId, 'custom', sourceId, content, now);
+
+    const pin: Pin = { id, channelId, type: 'custom', sourceId, content, updatedAt: now };
+    this.broadcast({ type: 'pin_updated', channelId, pin });
+  }
+
+  private handlePinMessage(channelId: string, messageId: string): void {
+    const db = getDb();
+    const msgRow = db.prepare('SELECT * FROM messages WHERE id = ?').get(messageId) as any;
+    if (!msgRow) return;
+
+    const id = uuid();
+    const now = new Date().toISOString();
+    const content = msgRow.content.length > 200 ? msgRow.content.slice(0, 200) + '...' : msgRow.content;
+
+    db.prepare(
+      'INSERT INTO pins (id, channel_id, type, source_id, content, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, channelId, 'message', messageId, content, now);
+
+    const pin: Pin = { id, channelId, type: 'message', sourceId: messageId, content, updatedAt: now };
+    this.broadcast({ type: 'pin_updated', channelId, pin });
+  }
+
+  private handlePinDelete(pinId: string): void {
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM pins WHERE id = ?').get(pinId) as any;
+    if (!row) return;
+
+    const channelId = row.channel_id;
+    db.prepare('DELETE FROM pins WHERE id = ?').run(pinId);
+    this.broadcast({ type: 'pin_deleted', channelId, pinId });
   }
 
   /** Pin sync: when a north star changes, update/create pins in relevant channels. */

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -70,6 +70,9 @@ export type ClientMessage =
   | { type: 'north_star_get'; scope?: string }
   | { type: 'north_star_set'; scope: string; content: string }
   | { type: 'pin_list'; channelId: string }
+  | { type: 'pin_create'; channelId: string; content: string; label?: string }
+  | { type: 'pin_message'; channelId: string; messageId: string }
+  | { type: 'pin_delete'; pinId: string }
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
@@ -94,6 +97,7 @@ export type ServerMessage =
   | { type: 'north_star_list'; stars: NorthStar[] }
   | { type: 'pin_list'; channelId: string; pins: Pin[] }
   | { type: 'pin_updated'; channelId: string; pin: Pin }
+  | { type: 'pin_deleted'; channelId: string; pinId: string }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
@@ -107,7 +111,7 @@ export interface NorthStar {
   updatedAt: string;
 }
 
-export type PinType = 'todo_section' | 'north_star' | 'custom';
+export type PinType = 'todo_section' | 'north_star' | 'custom' | 'message';
 
 export interface Pin {
   id: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,6 +109,12 @@ export default function App() {
           return { ...prev, [msg.channelId]: updated };
         });
         break;
+      case 'pin_deleted':
+        setPins((prev) => {
+          const channelPins = prev[msg.channelId] || [];
+          return { ...prev, [msg.channelId]: channelPins.filter((p) => p.id !== msg.pinId) };
+        });
+        break;
       case 'patrol_config':
         setPatrolConfigState(msg.config);
         break;
@@ -211,6 +217,9 @@ export default function App() {
         onOpenSettings={activeChannel ? () => setShowChannelSettings(true) : undefined}
         onToggleTodo={() => setShowTodoPanel((v) => !v)}
         onPatrolTrigger={handlePatrolTrigger}
+        onPinCreate={(channelId, content, label) => send({ type: 'pin_create', channelId, content, label })}
+        onPinMessage={(channelId, messageId) => send({ type: 'pin_message', channelId, messageId })}
+        onPinDelete={(pinId) => send({ type: 'pin_delete', pinId })}
       />
       {showTodoPanel && (
         <TodoPanel

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { AgentList } from './components/AgentList';
 import { CreateChannelDialog } from './components/CreateChannelDialog';
 import { ChannelSettingsPanel } from './components/ChannelSettingsPanel';
 import { TodoPanel } from './components/TodoPanel';
+import { CronDashboard } from './components/CronDashboard';
 import { useWebSocket } from './hooks/useWebSocket';
 import type { Channel, Agent, Message, ServerMessage, TodoItem, NorthStar, Pin, PatrolConfig, Notification } from './types';
 
@@ -19,6 +20,7 @@ export default function App() {
   const [editingChannel, setEditingChannel] = useState<boolean>(false);
   const [showChannelSettings, setShowChannelSettings] = useState(false);
   const [showTodoPanel, setShowTodoPanel] = useState(false);
+  const [showCronDashboard, setShowCronDashboard] = useState(false);
   const [todoItems, setTodoItems] = useState<TodoItem[]>([]);
   const [northStars, setNorthStars] = useState<NorthStar[]>([]);
   const [pins, setPins] = useState<Record<string, Pin[]>>({});
@@ -194,6 +196,7 @@ export default function App() {
         onSelectChannel={setActiveChannelId}
         onCreateChannel={handleCreateChannel}
         onOpenSettings={(channelId) => { setActiveChannelId(channelId); setShowChannelSettings(true); }}
+        onOpenCronDashboard={() => setShowCronDashboard(true)}
       />
       <ChatView
         channel={activeChannel ?? null}
@@ -247,6 +250,13 @@ export default function App() {
             setShowChannelSettings(false);
           }}
           onPatrolConfigSave={handlePatrolConfigSet}
+        />
+      )}
+      {showCronDashboard && (
+        <CronDashboard
+          channels={channels}
+          onTrigger={(channelId) => send({ type: 'cron_trigger', channelId })}
+          onClose={() => setShowCronDashboard(false)}
         />
       )}
       {!connected && (

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { renderMessageContent } from '@/lib/mentions';
 import type { Agent, Channel, Message, Pin, Notification } from '../types';
@@ -23,14 +24,20 @@ interface ChatViewProps {
   onOpenSettings?: () => void;
   onToggleTodo?: () => void;
   onPatrolTrigger?: () => void;
+  onPinCreate?: (channelId: string, content: string, label?: string) => void;
+  onPinMessage?: (channelId: string, messageId: string) => void;
+  onPinDelete?: (pinId: string) => void;
 }
 
-export function ChatView({ channel, messages, channelAgents, typingNames, pins, notifications, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onToggleTodo, onPatrolTrigger }: ChatViewProps) {
+export function ChatView({ channel, messages, channelAgents, typingNames, pins, notifications, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onToggleTodo, onPatrolTrigger, onPinCreate, onPinMessage, onPinDelete }: ChatViewProps) {
   const [input, setInput] = useState('');
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
   const [cursorPos, setCursorPos] = useState(0);
   const [expandedPinId, setExpandedPinId] = useState<string | null>(null);
+  const [showPinForm, setShowPinForm] = useState(false);
+  const [pinFormContent, setPinFormContent] = useState('');
+  const [pinFormLabel, setPinFormLabel] = useState('');
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -193,30 +200,93 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
         </div>
       </div>
       {/* Pinned items bar */}
-      {pins.length > 0 && (
+      {(pins.length > 0 || onPinCreate) && channel && (
         <div className="px-4 py-1.5 border-b border-border bg-card/50">
           <div className="flex items-center gap-2 overflow-x-auto">
             <span className="text-[10px] text-muted-foreground shrink-0">Pinned:</span>
             {pins.map((pin) => {
-              const label = pin.type === 'north_star' ? 'North Star' : pin.sourceId;
+              const label = pin.type === 'north_star' ? 'North Star'
+                : pin.type === 'message' ? '\ud83d\udccc Message'
+                : pin.type === 'custom' ? (pin.sourceId !== 'custom' ? `\ud83d\udcdd ${pin.sourceId}` : '\ud83d\udcdd Custom')
+                : pin.sourceId;
               const isExpanded = expandedPinId === pin.id;
+              const colorClass = pin.type === 'north_star'
+                ? 'bg-yellow-400/10 text-yellow-400 border-yellow-400/30'
+                : pin.type === 'message'
+                ? 'bg-purple-400/10 text-purple-400 border-purple-400/30'
+                : pin.type === 'custom'
+                ? 'bg-green-400/10 text-green-400 border-green-400/30'
+                : 'bg-blue-400/10 text-blue-400 border-blue-400/30';
               return (
-                <button
+                <span
                   key={pin.id}
                   className={cn(
-                    'shrink-0 px-2 py-0.5 rounded text-[11px] cursor-pointer border',
-                    pin.type === 'north_star'
-                      ? 'bg-yellow-400/10 text-yellow-400 border-yellow-400/30'
-                      : 'bg-blue-400/10 text-blue-400 border-blue-400/30',
+                    'group shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] border',
+                    colorClass,
                     isExpanded && 'ring-1 ring-offset-1 ring-offset-background ring-foreground/20'
                   )}
-                  onClick={() => setExpandedPinId(isExpanded ? null : pin.id)}
-                  title={pin.content.slice(0, 100)}
                 >
-                  {label}
-                </button>
+                  <button
+                    className="cursor-pointer"
+                    onClick={() => setExpandedPinId(isExpanded ? null : pin.id)}
+                    title={pin.content.slice(0, 100)}
+                  >
+                    {label}
+                  </button>
+                  {onPinDelete && (
+                    <button
+                      className="cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity text-current hover:text-foreground ml-0.5 text-[10px] leading-none"
+                      onClick={(e) => { e.stopPropagation(); onPinDelete(pin.id); }}
+                      title="Unpin"
+                    >
+                      &#10005;
+                    </button>
+                  )}
+                </span>
               );
             })}
+            {onPinCreate && !showPinForm && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="shrink-0 h-5 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => setShowPinForm(true)}
+              >
+                + Pin
+              </Button>
+            )}
+            {showPinForm && (
+              <form
+                className="shrink-0 inline-flex items-center gap-1"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (pinFormContent.trim() && channel) {
+                    onPinCreate!(channel.id, pinFormContent.trim(), pinFormLabel.trim() || undefined);
+                    setPinFormContent('');
+                    setPinFormLabel('');
+                    setShowPinForm(false);
+                  }
+                }}
+              >
+                <input
+                  type="text"
+                  value={pinFormLabel}
+                  onChange={(e) => setPinFormLabel(e.target.value)}
+                  placeholder="Label"
+                  className="w-16 px-1.5 py-0.5 rounded bg-muted text-[11px] outline-none border border-border"
+                  autoFocus
+                />
+                <input
+                  type="text"
+                  value={pinFormContent}
+                  onChange={(e) => setPinFormContent(e.target.value)}
+                  placeholder="Content"
+                  className="w-32 px-1.5 py-0.5 rounded bg-muted text-[11px] outline-none border border-border"
+                />
+                <Button type="submit" variant="ghost" size="sm" className="h-5 px-1.5 text-[11px]">Add</Button>
+                <Button type="button" variant="ghost" size="sm" className="h-5 px-1.5 text-[11px] text-muted-foreground" onClick={() => setShowPinForm(false)}>&#10005;</Button>
+              </form>
+            )}
           </div>
           {expandedPinId && (() => {
             const pin = pins.find((p) => p.id === expandedPinId);
@@ -240,7 +310,7 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
             <div
               key={msg.id}
               className={cn(
-                'flex gap-3 py-1 mb-2',
+                'group flex gap-3 py-1 mb-2 relative',
                 msg.isUrgent && 'border-l-2 border-red-500 pl-2'
               )}
             >
@@ -252,7 +322,7 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
               >
                 {msg.senderName.charAt(0).toUpperCase()}
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <div className="flex items-baseline gap-2 mb-0.5">
                   <span className="font-semibold text-sm">{msg.senderName}</span>
                   <span className="text-[11px] text-muted-foreground">{formatTime(msg.timestamp)}</span>
@@ -264,6 +334,15 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
                   {renderMessageContent(msg.content, channelAgents)}
                 </div>
               </div>
+              {onPinMessage && channel && (
+                <button
+                  className="cursor-pointer absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground/50 hover:text-foreground text-sm"
+                  onClick={() => onPinMessage(channel.id, msg.id)}
+                  title="Pin this message"
+                >
+                  &#128204;
+                </button>
+              )}
             </div>
           ))}
           {notifications.filter(n => !n.read).map((notif) => (

--- a/web/src/components/CronDashboard.tsx
+++ b/web/src/components/CronDashboard.tsx
@@ -1,0 +1,94 @@
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import type { Channel } from '../types';
+
+interface CronDashboardProps {
+  channels: Channel[];
+  onTrigger: (channelId: string) => void;
+  onClose: () => void;
+}
+
+function formatSchedule(schedule: string | null): string {
+  if (!schedule) return '—';
+  return schedule;
+}
+
+export function CronDashboard({ channels, onTrigger, onClose }: CronDashboardProps) {
+  const cronChannels = channels.filter((c) => c.cronEnabled || c.cronSchedule);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-card border border-border rounded-lg shadow-xl w-[640px] max-h-[80vh] flex flex-col">
+        <div className="p-4 border-b border-border flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-base">&#128339;</span>
+            <span className="font-semibold text-sm">Cron Dashboard</span>
+          </div>
+          <button
+            className="text-muted-foreground hover:text-foreground cursor-pointer text-lg leading-none"
+            onClick={onClose}
+          >
+            &times;
+          </button>
+        </div>
+
+        {cronChannels.length === 0 ? (
+          <div className="p-8 text-center text-muted-foreground text-sm">
+            <div className="text-3xl mb-3">&#128339;</div>
+            <div className="font-medium mb-1">No cron channels configured</div>
+            <div className="text-xs">Enable cron scheduling in channel settings to see channels here.</div>
+          </div>
+        ) : (
+          <ScrollArea className="flex-1">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-xs text-muted-foreground uppercase tracking-wide">
+                  <th className="text-left p-3 font-semibold">Channel</th>
+                  <th className="text-left p-3 font-semibold">Schedule</th>
+                  <th className="text-left p-3 font-semibold">Status</th>
+                  <th className="text-right p-3 font-semibold">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {cronChannels.map((channel) => (
+                  <tr key={channel.id} className="border-b border-border last:border-b-0 hover:bg-muted/50">
+                    <td className="p-3">
+                      <span className="text-muted-foreground/60 font-semibold mr-1">#</span>
+                      {channel.name}
+                    </td>
+                    <td className="p-3">
+                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded">{formatSchedule(channel.cronSchedule)}</code>
+                    </td>
+                    <td className="p-3">
+                      {channel.cronEnabled ? (
+                        <span className="inline-flex items-center gap-1 text-green-400 text-xs font-medium">
+                          <span className="w-1.5 h-1.5 rounded-full bg-green-400 inline-block" />
+                          Active
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
+                          <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground inline-block" />
+                          Paused
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3 text-right">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => onTrigger(channel.id)}
+                      >
+                        Trigger
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </ScrollArea>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -13,14 +13,24 @@ interface SidebarProps {
   onSelectChannel: (channelId: string) => void;
   onCreateChannel: (name: string, agents: { id: string; requireMention: boolean }[]) => void;
   onOpenSettings: (channelId: string) => void;
+  onOpenCronDashboard: () => void;
 }
 
-export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings }: SidebarProps) {
+export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard }: SidebarProps) {
   const [showDialog, setShowDialog] = useState(false);
 
   return (
     <div className="w-60 bg-card border-r border-border flex flex-col">
-      <div className="p-3 px-4 font-semibold text-sm border-b border-border">Workshop</div>
+      <div className="p-3 px-4 font-semibold text-sm border-b border-border flex items-center justify-between">
+        <span>Workshop</span>
+        <button
+          className="inline-flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:bg-accent hover:text-foreground text-sm leading-none cursor-pointer"
+          onClick={onOpenCronDashboard}
+          title="Cron Dashboard"
+        >
+          &#128339;
+        </button>
+      </div>
       <ScrollArea className="flex-1">
         <div className="p-2">
           <div className="flex items-center justify-between px-3 pb-2 pt-1">

--- a/web/src/components/TodoPanel.tsx
+++ b/web/src/components/TodoPanel.tsx
@@ -15,13 +15,15 @@ interface TodoPanelProps {
   onSetNorthStar: (scope: string, content: string) => void;
 }
 
+type ViewMode = 'list' | 'kanban';
+
 const STATUS_CYCLE: TodoStatus[] = ['pending', 'in_progress', 'review', 'done'];
 
-const STATUS_CONFIG: Record<TodoStatus, { label: string; color: string; bg: string }> = {
-  pending: { label: 'Pending', color: 'text-muted-foreground', bg: 'bg-muted-foreground/20' },
-  in_progress: { label: 'In Progress', color: 'text-blue-400', bg: 'bg-blue-400/20' },
-  review: { label: 'Review', color: 'text-yellow-400', bg: 'bg-yellow-400/20' },
-  done: { label: 'Done', color: 'text-green-400', bg: 'bg-green-400/20' },
+const STATUS_CONFIG: Record<TodoStatus, { label: string; color: string; bg: string; headerBg: string }> = {
+  pending: { label: 'Pending', color: 'text-muted-foreground', bg: 'bg-muted-foreground/20', headerBg: 'bg-muted-foreground/10' },
+  in_progress: { label: 'In Progress', color: 'text-blue-400', bg: 'bg-blue-400/20', headerBg: 'bg-blue-400/10' },
+  review: { label: 'Review', color: 'text-yellow-400', bg: 'bg-yellow-400/20', headerBg: 'bg-yellow-400/10' },
+  done: { label: 'Done', color: 'text-green-400', bg: 'bg-green-400/20', headerBg: 'bg-green-400/10' },
 };
 
 function isStale(updatedAt: string): boolean {
@@ -34,15 +36,25 @@ export function TodoPanel({ items, northStars, onClose, onCreate, onUpdate, onDe
   const [newContent, setNewContent] = useState('');
   const [editingNorthStar, setEditingNorthStar] = useState(false);
   const [northStarDraft, setNorthStarDraft] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
 
   const globalStar = northStars.find((s) => s.scope === 'global');
 
-  // Group by section
+  // Group by section (for list view)
   const sections = new Map<string, TodoItem[]>();
   for (const item of items) {
     const list = sections.get(item.section) || [];
     list.push(item);
     sections.set(item.section, list);
+  }
+
+  // Group by status (for kanban view)
+  const columns = new Map<TodoStatus, TodoItem[]>();
+  for (const status of STATUS_CYCLE) {
+    columns.set(status, []);
+  }
+  for (const item of items) {
+    columns.get(item.status)!.push(item);
   }
 
   const handleAdd = () => {
@@ -59,12 +71,37 @@ export function TodoPanel({ items, northStars, onClose, onCreate, onUpdate, onDe
   };
 
   return (
-    <div className="w-72 bg-card border-l border-border flex flex-col shrink-0">
+    <div className={cn(
+      'bg-card border-l border-border flex flex-col shrink-0 transition-[width] duration-200',
+      viewMode === 'kanban' ? 'w-[800px]' : 'w-72'
+    )}>
       <div className="p-3 px-4 font-semibold text-sm border-b border-border flex items-center justify-between">
         <span>TODO</span>
-        <button className="text-muted-foreground hover:text-foreground cursor-pointer text-lg leading-none" onClick={onClose}>
-          &times;
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            className={cn(
+              'px-1.5 py-0.5 rounded text-xs cursor-pointer',
+              viewMode === 'list' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setViewMode('list')}
+            title="List view"
+          >
+            &#9776;
+          </button>
+          <button
+            className={cn(
+              'px-1.5 py-0.5 rounded text-xs cursor-pointer',
+              viewMode === 'kanban' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => setViewMode('kanban')}
+            title="Kanban view"
+          >
+            &#8862;
+          </button>
+          <button className="text-muted-foreground hover:text-foreground cursor-pointer text-lg leading-none ml-2" onClick={onClose}>
+            &times;
+          </button>
+        </div>
       </div>
 
       {/* North Star section */}
@@ -106,51 +143,119 @@ export function TodoPanel({ items, northStars, onClose, onCreate, onUpdate, onDe
         )}
       </div>
 
-      <ScrollArea className="flex-1">
-        <div className="p-3 space-y-4">
-          {sections.size === 0 && (
-            <div className="text-muted-foreground text-xs text-center py-4">No todo items yet</div>
-          )}
-          {Array.from(sections.entries()).map(([section, sectionItems]) => (
-            <div key={section}>
-              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">{section}</div>
-              <div className="space-y-1">
-                {sectionItems.map((item) => {
-                  const cfg = STATUS_CONFIG[item.status];
-                  const stale = item.status !== 'done' && isStale(item.updatedAt);
-                  return (
-                    <div
-                      key={item.id}
-                      className={cn(
-                        'group flex items-start gap-2 p-2 rounded text-sm hover:bg-muted',
-                        stale && 'border-l-2 border-orange-400'
-                      )}
-                    >
-                      <button
-                        className={cn('shrink-0 mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium cursor-pointer', cfg.bg, cfg.color)}
-                        onClick={() => cycleStatus(item)}
-                        title={`Status: ${cfg.label} — click to cycle`}
+      {/* List view */}
+      {viewMode === 'list' && (
+        <ScrollArea className="flex-1">
+          <div className="p-3 space-y-4">
+            {sections.size === 0 && (
+              <div className="text-muted-foreground text-xs text-center py-4">No todo items yet</div>
+            )}
+            {Array.from(sections.entries()).map(([section, sectionItems]) => (
+              <div key={section}>
+                <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">{section}</div>
+                <div className="space-y-1">
+                  {sectionItems.map((item) => {
+                    const cfg = STATUS_CONFIG[item.status];
+                    const stale = item.status !== 'done' && isStale(item.updatedAt);
+                    return (
+                      <div
+                        key={item.id}
+                        className={cn(
+                          'group flex items-start gap-2 p-2 rounded text-sm hover:bg-muted',
+                          stale && 'border-l-2 border-orange-400'
+                        )}
                       >
-                        {cfg.label}
-                      </button>
-                      <span className={cn('flex-1 break-words', item.status === 'done' && 'line-through text-muted-foreground')}>
-                        {item.content}
-                      </span>
-                      <button
-                        className="shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive cursor-pointer text-xs"
-                        onClick={() => onDelete(item.id)}
-                        title="Delete"
-                      >
-                        &times;
-                      </button>
-                    </div>
-                  );
-                })}
+                        <button
+                          className={cn('shrink-0 mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium cursor-pointer', cfg.bg, cfg.color)}
+                          onClick={() => cycleStatus(item)}
+                          title={`Status: ${cfg.label} — click to cycle`}
+                        >
+                          {cfg.label}
+                        </button>
+                        <span className={cn('flex-1 break-words', item.status === 'done' && 'line-through text-muted-foreground')}>
+                          {item.content}
+                        </span>
+                        <button
+                          className="shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive cursor-pointer text-xs"
+                          onClick={() => onDelete(item.id)}
+                          title="Delete"
+                        >
+                          &times;
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+
+      {/* Kanban view */}
+      {viewMode === 'kanban' && (
+        <div className="flex-1 flex gap-2 p-3 overflow-x-auto min-h-0">
+          {STATUS_CYCLE.map((status) => {
+            const cfg = STATUS_CONFIG[status];
+            const colItems = columns.get(status) || [];
+            return (
+              <div key={status} className="flex-1 min-w-[160px] flex flex-col min-h-0">
+                <div className={cn('rounded-t px-2 py-1.5 flex items-center gap-2', cfg.headerBg)}>
+                  <span className={cn('text-xs font-semibold', cfg.color)}>{cfg.label}</span>
+                  <span className="text-[10px] text-muted-foreground">{colItems.length}</span>
+                </div>
+                <ScrollArea className="flex-1 border border-t-0 border-border rounded-b">
+                  <div className="p-1.5 space-y-1.5">
+                    {colItems.length === 0 && (
+                      <div className="text-muted-foreground text-[10px] text-center py-3">Empty</div>
+                    )}
+                    {colItems.map((item) => {
+                      const stale = item.status !== 'done' && isStale(item.updatedAt);
+                      return (
+                        <div
+                          key={item.id}
+                          className={cn(
+                            'group bg-muted/50 rounded p-2 text-xs hover:bg-muted',
+                            stale && 'border-l-2 border-orange-400'
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-1">
+                            <span className={cn('flex-1 break-words', item.status === 'done' && 'line-through text-muted-foreground')}>
+                              {item.content}
+                            </span>
+                            <button
+                              className="shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive cursor-pointer text-[10px]"
+                              onClick={() => onDelete(item.id)}
+                              title="Delete"
+                            >
+                              &times;
+                            </button>
+                          </div>
+                          <div className="mt-1.5 flex items-center gap-1.5">
+                            <button
+                              className={cn('px-1.5 py-0.5 rounded text-[9px] font-medium cursor-pointer', cfg.bg, cfg.color)}
+                              onClick={() => cycleStatus(item)}
+                              title="Click to advance status"
+                            >
+                              {cfg.label}
+                            </button>
+                            <span className="text-[9px] text-muted-foreground/70 bg-muted-foreground/10 px-1 py-0.5 rounded">
+                              {item.section}
+                            </span>
+                            {stale && (
+                              <span className="text-[9px] text-orange-400" title="Stale — no update in 3+ days">&#9888;</span>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              </div>
+            );
+          })}
         </div>
-      </ScrollArea>
+      )}
 
       <div className="p-3 border-t border-border space-y-2">
         <Input

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -52,7 +52,7 @@ export interface NorthStar {
   updatedAt: string;
 }
 
-export type PinType = 'todo_section' | 'north_star' | 'custom';
+export type PinType = 'todo_section' | 'north_star' | 'custom' | 'message';
 
 export interface Pin {
   id: string;
@@ -93,6 +93,7 @@ export type ServerMessage =
   | { type: 'north_star_list'; stars: NorthStar[] }
   | { type: 'pin_list'; channelId: string; pins: Pin[] }
   | { type: 'pin_updated'; channelId: string; pin: Pin }
+  | { type: 'pin_deleted'; channelId: string; pinId: string }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
@@ -116,6 +117,9 @@ export type ClientMessage =
   | { type: 'north_star_get'; scope?: string }
   | { type: 'north_star_set'; scope: string; content: string }
   | { type: 'pin_list'; channelId: string }
+  | { type: 'pin_create'; channelId: string; content: string; label?: string }
+  | { type: 'pin_message'; channelId: string; messageId: string }
+  | { type: 'pin_delete'; pinId: string }
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }


### PR DESCRIPTION
## v0.3 Phase 3: Pin Sync Expansion

Implements full pin CRUD so any content or message can be pinned to any channel.

### Changes

**Types** (server + client):
- Added `message` to `PinType` union
- Added `pin_create`, `pin_message`, `pin_delete` client messages
- Added `pin_deleted` server message

**Server** (`router.ts`):
- `handlePinCreate` — create custom pins with optional label
- `handlePinMessage` — pin a message (truncates content to 200 chars)
- `handlePinDelete` — delete pin + broadcast `pin_deleted`

**Frontend** (`App.tsx` + `ChatView.tsx`):
- Pin bar with distinct colors per type (yellow=north_star, purple=message, green=custom, blue=todo_section)
- Hover-visible ✕ unpin button on each pin chip
- 📌 hover icon on messages for quick pinning
- "+ Pin" button opens inline form (label + content) for custom pins
- `pin_deleted` state handler

### Build
Both `web` and `server` compile clean (`tsc --noEmit`).

Closes the last item in v0.3 Phase 3 (Polish).
