### PR TITLE
feat: runtime agent management (register/update/remove without restart)

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -32,6 +32,7 @@
 4. **Isolation by default, communication by intent** — Agents don't see everything. They communicate when needed, explicitly.
 5. **Platform-agnostic core** — Works on Discord today, should work on Slack/Feishu tomorrow.
 6. **Dogfood-driven** — We build what we need, then generalize.
+7. **Runtime-dynamic, no restarts** — Every management operation (channels, agents, config) must be achievable at runtime through the API/UI. No operation should require a server restart. This is a hard constraint, not a nice-to-have. (Lesson from OpenClaw Discord allowlist requiring gateway restart on config change — openclaw#59372.)
 
 ## Open Questions
 

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -181,6 +181,15 @@ export class Router {
       case 'notification_mark_read':
         this.handleNotificationMarkRead(msg.channelId);
         break;
+      case 'register_agent':
+        this.handleRegisterAgent(ws, msg.agent);
+        break;
+      case 'update_agent':
+        this.handleUpdateAgent(ws, msg.id, msg.updates);
+        break;
+      case 'remove_agent':
+        this.handleRemoveAgent(ws, msg.id);
+        break;
       default:
         this.sendTo(ws, { type: 'error', message: 'Unknown message type' });
     }
@@ -865,6 +874,110 @@ export class Router {
 
       console.log(`[notify] #${sourceChannelId} → #${targetChannel.id}: "${notifyContent.slice(0, 80)}"`);
       this.postNotification(sourceChannelId, targetChannel.id, notifyContent, 'agent_crosspost');
+    }
+  }
+
+  // --- Runtime agent management ---
+
+  private handleRegisterAgent(ws: WebSocket, agentData: { id: string; name: string; avatar?: string }): void {
+    const db = getDb();
+
+    // Validate unique ID
+    const existing = db.prepare('SELECT id FROM agents WHERE id = ?').get(agentData.id);
+    if (existing || this.agents.has(agentData.id)) {
+      this.sendTo(ws, { type: 'error', message: `Agent with id '${agentData.id}' already exists` });
+      return;
+    }
+
+    const agent: Agent = {
+      id: agentData.id,
+      name: agentData.name,
+      avatar: agentData.avatar,
+      status: 'offline',
+    };
+
+    db.prepare('INSERT INTO agents (id, name, avatar, status) VALUES (?, ?, ?, ?)').run(
+      agent.id, agent.name, agent.avatar ?? null, agent.status,
+    );
+    this.agents.set(agent.id, agent);
+
+    this.broadcast({ type: 'agent_registered', agent });
+  }
+
+  private handleUpdateAgent(ws: WebSocket, id: string, updates: Partial<{ name: string; avatar: string }>): void {
+    const db = getDb();
+
+    const agent = this.agents.get(id);
+    if (!agent) {
+      this.sendTo(ws, { type: 'error', message: `Agent '${id}' not found` });
+      return;
+    }
+
+    const sqlUpdates: string[] = [];
+    const values: any[] = [];
+
+    if (updates.name !== undefined) {
+      agent.name = updates.name;
+      sqlUpdates.push('name = ?');
+      values.push(updates.name);
+    }
+    if (updates.avatar !== undefined) {
+      agent.avatar = updates.avatar;
+      sqlUpdates.push('avatar = ?');
+      values.push(updates.avatar);
+    }
+
+    if (sqlUpdates.length === 0) return;
+
+    values.push(id);
+    db.prepare(`UPDATE agents SET ${sqlUpdates.join(', ')} WHERE id = ?`).run(...values);
+
+    this.broadcast({ type: 'agent_updated', agent });
+  }
+
+  private handleRemoveAgent(ws: WebSocket, id: string): void {
+    const db = getDb();
+
+    const agent = this.agents.get(id);
+    if (!agent) {
+      this.sendTo(ws, { type: 'error', message: `Agent '${id}' not found` });
+      return;
+    }
+
+    // Find channels that will be affected by the removal
+    const affectedChannels = db.prepare(
+      'SELECT DISTINCT channel_id FROM channel_agents WHERE agent_id = ?'
+    ).all(id) as { channel_id: string }[];
+
+    // Cascade: remove from channel_agents
+    db.prepare('DELETE FROM channel_agents WHERE agent_id = ?').run(id);
+
+    // Remove the agent itself
+    db.prepare('DELETE FROM agents WHERE id = ?').run(id);
+    this.agents.delete(id);
+
+    this.broadcast({ type: 'agent_removed', id });
+
+    // Broadcast channel_updated for each affected channel so UIs refresh membership
+    for (const { channel_id } of affectedChannels) {
+      const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channel_id) as any;
+      if (!row) continue;
+
+      const agents = db.prepare(
+        'SELECT agent_id, require_mention FROM channel_agents WHERE channel_id = ?'
+      ).all(channel_id) as { agent_id: string; require_mention: number }[];
+
+      const channel: Channel = {
+        id: row.id, name: row.name,
+        agents: agents.map(a => a.agent_id),
+        agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
+        createdAt: row.created_at, status: row.status,
+        type: row.type ?? 'project', positioning: row.positioning ?? '',
+        guidelines: row.guidelines ?? '', northStar: row.north_star ?? '',
+        todoSection: row.todo_section ?? null, cronSchedule: row.cron_schedule ?? null,
+        cronEnabled: !!row.cron_enabled,
+      };
+      this.broadcast({ type: 'channel_updated', channel });
     }
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -76,7 +76,10 @@ export type ClientMessage =
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
-  | { type: 'notification_mark_read'; channelId: string };
+  | { type: 'notification_mark_read'; channelId: string }
+  | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
+  | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
+  | { type: 'remove_agent'; id: string };
 
 // WebSocket protocol: server → client
 export type ServerMessage =
@@ -102,6 +105,9 @@ export type ServerMessage =
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
   | { type: 'notification_badge'; channelId: string; unreadCount: number }
+  | { type: 'agent_registered'; agent: Agent }
+  | { type: 'agent_updated'; agent: Agent }
+  | { type: 'agent_removed'; id: string }
   | { type: 'error'; message: string };
 
 export interface NorthStar {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -127,6 +127,15 @@ export default function App() {
       case 'notification_badge':
         setNotificationBadges((prev) => ({ ...prev, [msg.channelId]: msg.unreadCount }));
         break;
+      case 'agent_registered':
+        setAgents((prev) => [...prev, msg.agent]);
+        break;
+      case 'agent_updated':
+        setAgents((prev) => prev.map((a) => a.id === msg.agent.id ? msg.agent : a));
+        break;
+      case 'agent_removed':
+        setAgents((prev) => prev.filter((a) => a.id !== msg.id));
+        break;
       case 'error':
         console.error('[workshop]', msg.message);
         break;
@@ -166,6 +175,18 @@ export default function App() {
 
   const handleNotificationMarkRead = (channelId: string) => {
     send({ type: 'notification_mark_read', channelId });
+  };
+
+  const handleRegisterAgent = (agent: { id: string; name: string; avatar?: string }) => {
+    send({ type: 'register_agent', agent });
+  };
+
+  const handleUpdateAgent = (id: string, updates: Partial<{ name: string; avatar: string }>) => {
+    send({ type: 'update_agent', id, updates });
+  };
+
+  const handleRemoveAgent = (id: string) => {
+    send({ type: 'remove_agent', id });
   };
 
   // Request pins when active channel changes
@@ -232,7 +253,12 @@ export default function App() {
           onSetNorthStar={handleSetNorthStar}
         />
       )}
-      <AgentList agents={agents} />
+      <AgentList
+        agents={agents}
+        onRegisterAgent={handleRegisterAgent}
+        onUpdateAgent={handleUpdateAgent}
+        onRemoveAgent={handleRemoveAgent}
+      />
       {editingChannel && activeChannel && (
         <CreateChannelDialog
           agents={agents}

--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -1,12 +1,135 @@
+import { useState } from 'react';
 import type { Agent } from '../types';
 
 interface AgentListProps {
   agents: Agent[];
+  onRegisterAgent: (agent: { id: string; name: string; avatar?: string }) => void;
+  onUpdateAgent: (id: string, updates: Partial<{ name: string; avatar: string }>) => void;
+  onRemoveAgent: (id: string) => void;
 }
 
-export function AgentList({ agents }: AgentListProps) {
+export function AgentList({ agents, onRegisterAgent, onUpdateAgent, onRemoveAgent }: AgentListProps) {
   const online = agents.filter((a) => a.status === 'online');
   const offline = agents.filter((a) => a.status !== 'online');
+
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newId, setNewId] = useState('');
+  const [newName, setNewName] = useState('');
+  const [newAvatar, setNewAvatar] = useState('');
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editAvatar, setEditAvatar] = useState('');
+
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    if (!newId.trim() || !newName.trim()) return;
+    onRegisterAgent({ id: newId.trim(), name: newName.trim(), avatar: newAvatar.trim() || undefined });
+    setNewId('');
+    setNewName('');
+    setNewAvatar('');
+    setShowAddForm(false);
+  };
+
+  const startEdit = (agent: Agent) => {
+    setEditingId(agent.id);
+    setEditName(agent.name);
+    setEditAvatar(agent.avatar ?? '');
+  };
+
+  const handleSaveEdit = () => {
+    if (!editingId) return;
+    onUpdateAgent(editingId, { name: editName.trim(), avatar: editAvatar.trim() });
+    setEditingId(null);
+  };
+
+  const handleRemove = (id: string) => {
+    onRemoveAgent(id);
+    setConfirmRemoveId(null);
+  };
+
+  const renderAgent = (agent: Agent) => {
+    const isOnline = agent.status === 'online';
+
+    if (editingId === agent.id) {
+      return (
+        <div key={agent.id} className="mb-2 p-2 rounded bg-background border border-border">
+          <input
+            className="w-full mb-1 px-2 py-1 text-sm bg-background border border-border rounded"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            placeholder="Name"
+          />
+          <input
+            className="w-full mb-1 px-2 py-1 text-sm bg-background border border-border rounded"
+            value={editAvatar}
+            onChange={(e) => setEditAvatar(e.target.value)}
+            placeholder="Avatar URL"
+          />
+          <div className="flex gap-1">
+            <button
+              onClick={handleSaveEdit}
+              className="text-xs px-2 py-0.5 bg-discord-blurple text-white rounded hover:opacity-90"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => setEditingId(null)}
+              className="text-xs px-2 py-0.5 text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    if (confirmRemoveId === agent.id) {
+      return (
+        <div key={agent.id} className="mb-2 p-2 rounded bg-background border border-red-500/50">
+          <div className="text-xs text-red-400 mb-1">Remove {agent.name}?</div>
+          <div className="flex gap-1">
+            <button
+              onClick={() => handleRemove(agent.id)}
+              className="text-xs px-2 py-0.5 bg-red-500 text-white rounded hover:opacity-90"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => setConfirmRemoveId(null)}
+              className="text-xs px-2 py-0.5 text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div key={agent.id} className="group flex items-center gap-2 py-1 mb-1">
+        <div className={`w-2 h-2 rounded-full ${isOnline ? 'bg-discord-online' : 'bg-discord-offline'}`} />
+        <span className="text-sm text-muted-foreground flex-1">{agent.name}</span>
+        <div className="hidden group-hover:flex gap-0.5">
+          <button
+            onClick={() => startEdit(agent)}
+            className="text-xs text-muted-foreground hover:text-foreground px-1"
+            title="Edit"
+          >
+            &#9998;
+          </button>
+          <button
+            onClick={() => setConfirmRemoveId(agent.id)}
+            className="text-xs text-muted-foreground hover:text-red-400 px-1"
+            title="Remove"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div className="w-60 bg-card border-l border-border p-4">
@@ -15,12 +138,7 @@ export function AgentList({ agents }: AgentListProps) {
           <div className="text-xs font-semibold uppercase text-muted-foreground mb-3 tracking-wide">
             Online — {online.length}
           </div>
-          {online.map((agent) => (
-            <div key={agent.id} className="flex items-center gap-2 py-1 mb-1">
-              <div className="w-2 h-2 rounded-full bg-discord-online" />
-              <span className="text-sm text-muted-foreground">{agent.name}</span>
-            </div>
-          ))}
+          {online.map(renderAgent)}
         </>
       )}
       {offline.length > 0 && (
@@ -31,17 +149,60 @@ export function AgentList({ agents }: AgentListProps) {
           >
             Offline — {offline.length}
           </div>
-          {offline.map((agent) => (
-            <div key={agent.id} className="flex items-center gap-2 py-1 mb-1">
-              <div className="w-2 h-2 rounded-full bg-discord-offline" />
-              <span className="text-sm text-muted-foreground">{agent.name}</span>
-            </div>
-          ))}
+          {offline.map(renderAgent)}
         </>
       )}
       {agents.length === 0 && (
         <div className="text-muted-foreground text-[13px]">No agents connected</div>
       )}
+
+      {/* Add agent form */}
+      <div className="mt-4 pt-3 border-t border-border">
+        {showAddForm ? (
+          <div className="space-y-1">
+            <input
+              className="w-full px-2 py-1 text-sm bg-background border border-border rounded"
+              value={newId}
+              onChange={(e) => setNewId(e.target.value)}
+              placeholder="Agent ID"
+            />
+            <input
+              className="w-full px-2 py-1 text-sm bg-background border border-border rounded"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Display name"
+            />
+            <input
+              className="w-full px-2 py-1 text-sm bg-background border border-border rounded"
+              value={newAvatar}
+              onChange={(e) => setNewAvatar(e.target.value)}
+              placeholder="Avatar URL (optional)"
+            />
+            <div className="flex gap-1">
+              <button
+                onClick={handleAdd}
+                disabled={!newId.trim() || !newName.trim()}
+                className="text-xs px-2 py-1 bg-discord-blurple text-white rounded hover:opacity-90 disabled:opacity-50"
+              >
+                Add Agent
+              </button>
+              <button
+                onClick={() => setShowAddForm(false)}
+                className="text-xs px-2 py-1 text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="w-full text-xs text-muted-foreground hover:text-foreground py-1"
+          >
+            + Add Agent
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -98,6 +98,9 @@ export type ServerMessage =
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
   | { type: 'notification_badge'; channelId: string; unreadCount: number }
+  | { type: 'agent_registered'; agent: Agent }
+  | { type: 'agent_updated'; agent: Agent }
+  | { type: 'agent_removed'; id: string }
   | { type: 'error'; message: string };
 
 // Messages from client → server
@@ -123,7 +126,10 @@ export type ClientMessage =
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
-  | { type: 'notification_mark_read'; channelId: string };
+  | { type: 'notification_mark_read'; channelId: string }
+  | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
+  | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
+  | { type: 'remove_agent'; id: string };
 
 export interface CreateChannelDialogProps {
   agents: Agent[];


### PR DESCRIPTION
## Summary

Implement runtime agent CRUD via WebSocket, eliminating the need to restart the server when adding or removing agents.

Previously, agents could only be registered at startup from `workshop.json`. Channels were already runtime-dynamic, but agents were a gap. This PR closes that gap.

### Server
- Add `register_agent`, `update_agent`, `remove_agent` WebSocket message types
- Handlers validate uniqueness, mutate DB + in-memory state, broadcast to all clients
- Agent removal cascades to `channel_agents` and broadcasts `channel_updated` for affected channels

### Web
- `AgentList` now has: add form (id, name, avatar URL), per-agent edit/remove, confirmation dialog
- `App.tsx` handles `agent_registered`/`agent_updated`/`agent_removed` server messages

### Docs
- Design principle #7: **Runtime-dynamic, no restarts**

## Build
Both server and web TypeScript compilation pass with zero errors.