### PR TITLE
feat: WebSocket auto-reconnect with exponential backoff

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -142,7 +142,7 @@ export default function App() {
     }
   }, []);
 
-  const { send, connected } = useWebSocket(WS_URL, handleMessage);
+  const { send, connected, status, reconnectAttempt } = useWebSocket(WS_URL, handleMessage);
 
   const handleSendMessage = (content: string) => {
     if (!activeChannelId) return;
@@ -294,8 +294,13 @@ export default function App() {
           onClose={() => setShowCronDashboard(false)}
         />
       )}
-      {!connected && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded text-sm">
+      {status === 'reconnecting' && (
+        <div className="fixed top-0 left-0 right-0 bg-yellow-500 text-yellow-950 text-center text-sm py-1.5 font-medium z-50">
+          Reconnecting{reconnectAttempt > 0 ? ` (attempt ${reconnectAttempt})` : ''}...
+        </div>
+      )}
+      {status === 'disconnected' && (
+        <div className="fixed top-0 left-0 right-0 bg-red-500 text-white text-center text-sm py-1.5 font-medium z-50">
           Disconnected from server
         </div>
       )}

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -3,37 +3,125 @@ import type { ServerMessage } from '../types';
 
 type MessageHandler = (msg: ServerMessage) => void;
 
+export type ConnectionStatus = 'connected' | 'reconnecting' | 'disconnected';
+
+const BACKOFF_BASE = 1000;
+const BACKOFF_MAX = 30000;
+
+function getBackoff(attempt: number): number {
+  return Math.min(BACKOFF_BASE * Math.pow(2, attempt), BACKOFF_MAX);
+}
+
 export function useWebSocket(url: string, onMessage: MessageHandler) {
   const wsRef = useRef<WebSocket | null>(null);
-  const [connected, setConnected] = useState(false);
+  const onMessageRef = useRef(onMessage);
+  const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
 
-  useEffect(() => {
+  // Keep the callback ref current without triggering reconnects
+  onMessageRef.current = onMessage;
+
+  // Track whether the hook is still mounted and whether disconnect was intentional
+  const mountedRef = useRef(true);
+  const intentionalCloseRef = useRef(false);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasConnectedOnceRef = useRef(false);
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current) return;
+
+    // Clean up previous connection if any
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onerror = null;
+      if (wsRef.current.readyState === WebSocket.OPEN || wsRef.current.readyState === WebSocket.CONNECTING) {
+        wsRef.current.close();
+      }
+    }
+
     const ws = new WebSocket(url);
     wsRef.current = ws;
 
     ws.onopen = () => {
+      if (!mountedRef.current) return;
       console.log('[ws] connected');
-      setConnected(true);
+      const wasReconnect = hasConnectedOnceRef.current;
+      hasConnectedOnceRef.current = true;
+      setStatus('connected');
+      setReconnectAttempt(0);
+      if (wasReconnect) {
+        console.log('[ws] reconnected — re-fetching state');
+      }
+      // Server sends channel_list and agent_list on connect,
+      // so reconnect automatically re-fetches state.
     };
 
     ws.onmessage = (event) => {
       try {
         const msg: ServerMessage = JSON.parse(event.data);
-        onMessage(msg);
+        onMessageRef.current(msg);
       } catch {
         // ignore
       }
     };
 
-    ws.onclose = () => {
-      console.log('[ws] disconnected');
-      setConnected(false);
+    ws.onerror = (event) => {
+      console.warn('[ws] error', event);
     };
 
-    return () => {
-      ws.close();
+    ws.onclose = () => {
+      if (!mountedRef.current) return;
+
+      console.log('[ws] disconnected');
+
+      if (intentionalCloseRef.current) {
+        setStatus('disconnected');
+        return;
+      }
+
+      // Start reconnecting
+      setStatus('reconnecting');
+      setReconnectAttempt((prev) => {
+        const attempt = prev;
+        const delay = getBackoff(attempt);
+        console.log(`[ws] reconnecting in ${delay}ms (attempt ${attempt + 1})`);
+
+        reconnectTimerRef.current = setTimeout(() => {
+          if (mountedRef.current) {
+            connect();
+          }
+        }, delay);
+
+        return attempt + 1;
+      });
     };
-  }, [url]); // intentionally omit onMessage to avoid reconnects
+  }, [url]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    intentionalCloseRef.current = false;
+    hasConnectedOnceRef.current = false;
+    setReconnectAttempt(0);
+
+    connect();
+
+    return () => {
+      mountedRef.current = false;
+      intentionalCloseRef.current = true;
+
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [connect]);
 
   const send = useCallback((data: unknown) => {
     const ws = wsRef.current;
@@ -42,5 +130,5 @@ export function useWebSocket(url: string, onMessage: MessageHandler) {
     }
   }, []);
 
-  return { send, connected };
+  return { send, connected: status === 'connected', status, reconnectAttempt };
 }


### PR DESCRIPTION
## Summary

Implements auto-reconnect for the WebSocket client with exponential backoff, closing #5.

### Changes

**`web/src/hooks/useWebSocket.ts`**
- Auto-reconnect on unexpected disconnect with exponential backoff (1s → 2s → 4s → ... → max 30s)
- `ConnectionStatus` type: `'connected' | 'reconnecting' | 'disconnected'`
- Returns `status`, `reconnectAttempt`, and backward-compatible `connected` boolean
- Unmount-safe: cancels reconnect timers and guards state updates with `mountedRef`
- Separates intentional close (component unmount) from unintentional (server crash)

**`web/src/App.tsx`**
- Yellow top banner during reconnection: "Reconnecting (attempt N)..."
- Red top banner when fully disconnected
- Replaces old floating bottom indicator

### Re-fetch on reconnect
Server already sends `channel_list`, `agent_list`, todos, north stars, message history, notification badges, and patrol config on every new connection (`router.ts:18-31`), so reconnecting automatically restores full state — no extra client logic needed.

### Build
Both `server` and `web` TypeScript compilation pass with zero errors.

Closes #5