### PR TITLE
docs: update CHANGELOG and README for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.3.0] — 2026-04-12
+
+### 🏗️ Channel Autonomy
+
+Workshop channels become autonomous: each channel has metadata, scheduling, task lifecycle, and cross-channel coordination — agents patrol, notify, and intervene without human prompting.
+
+- **Channel metadata system** — type (daily/project/meta), positioning, guidelines, north star per channel
+- **Channel settings panel** — UI for editing channel metadata; header shows type badge and positioning
+- **TODO section linking** — global TODO + per-channel task sections with TodoPanel component
+- **Pin sync** — pins synced from channel files; custom pins and message pinning in chat; Kanban view toggle
+- **NorthStar integration** — per-channel north star displayed and enforced
+- **Cron scheduling** — per-channel `cronSchedule` / `cronEnabled` with CronDashboard component
+- **Task lifecycle states** — created → assigned → in-progress → review → done
+- **Automated patrol** — agents patrol channels and post summaries to the control room
+- **Cross-channel notifications** — channels can notify other channels of events
+- **Real-time human intervention** — urgent intervention support during autonomous work
+
+### Added
+- **Runtime agent management** — register, update, and remove agents at runtime without server restart (#20)
+- **WebSocket auto-reconnect** — automatic reconnection with exponential backoff on disconnect (#21, fixes #5)
+- **@mention highlight** — mentioned agent names highlighted in messages (#16, fixes #4)
+
+### Fixed
+- **Security** — example config added, real config gitignored to prevent credential leaks
+
+### Infrastructure
+- **Comprehensive server-side test suite** — 49 tests covering server functionality (#22)
+- **Star history chart** — added to docs
+
 ## [0.2.0] — 2026-04-02
 
 ### ✨ Multi-Agent Chat

--- a/README.md
+++ b/README.md
@@ -66,21 +66,18 @@ You talk to one agent. It dispatches to a team. The team works in visible rooms.
 
 ## Status
 
-🟢 **v0.2.0 — Multi-agent chat** (2026-04-02)
+🟢 **v0.3.0 — Channel Autonomy** (2026-04-12)
 
-- Multiple agents per room (Kagura, Anan, Ruantang)
-- `requireMention` routing — agents only respond when @mentioned, or see everything
-- @mention autocomplete (type `@` to pick agents)
-- Typing indicator ("Kagura is typing...")
-- Message history on reconnect
-- SQLite persistence
-- Process supervisor with auto-restart
+v0.3 gives channels a life of their own: metadata (type, positioning, north star), cron scheduling, task lifecycle, cross-channel notifications, automated patrol, and real-time human intervention. Plus runtime agent management, WebSocket auto-reconnect, @mention highlights, and 49 server-side tests.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 ### What's next
-- [ ] @mention highlight in messages (#4)
-- [ ] WebSocket auto-reconnect (#5)
-- [ ] UI polish (avatars, markdown rendering)
-- [ ] Task lifecycle (created → assigned → done)
+- [ ] Fix Vite dev server crashes (#2)
+- [ ] Agent avatars and markdown rendering
+- [ ] Agent-to-agent direct messaging
+- [ ] Public spectator mode (read-only view for visitors)
+- [ ] Webhook integrations (GitHub, CI notifications)
 
 ## Quick Start
 


### PR DESCRIPTION
## Changes

- **CHANGELOG.md**: Added v0.3.0 entry documenting all features merged since v0.2.0:
  - Channel Autonomy (metadata, cron scheduling, task lifecycle, patrol, cross-channel notifications, intervention)
  - Runtime agent management (#20)
  - WebSocket auto-reconnect (#21, fixes #5)
  - @mention highlight (#16, fixes #4)
  - Server test suite (#22, 49 tests)
  - Security improvements

- **README.md**: Updated Status section from v0.2.0 → v0.3.0, replaced completed 'What's next' items with new roadmap items

All tests pass (49 server + 11 web).