### PR TITLE
fix: systemd user units for reliable process supervision

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "scripts": {
     "dev:server": "cd server && npm run dev",
     "dev:web": "cd web && npm run dev",
-    "build": "cd server && npm run build && cd ../web && npm run build"
+    "build": "cd server && npm run build && cd ../web && npm run build",
+    "install-services": "bash scripts/install-services.sh",
+    "uninstall-services": "bash scripts/uninstall-services.sh",
+    "status": "bash scripts/workshop-status.sh",
+    "logs:server": "journalctl --user -u workshop-server -f",
+    "logs:web": "journalctl --user -u workshop-web -f"
   },
   "dependencies": {
     "node-cron": "^4.2.1"

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Install workshop systemd user units for reliable process supervision.
+# Replaces the old scripts/supervise.sh approach.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UNIT_DIR="$HOME/.config/systemd/user"
+
+echo "==> Installing workshop systemd user units"
+
+mkdir -p "$UNIT_DIR"
+
+cp "$SCRIPT_DIR/systemd/workshop-server.service" "$UNIT_DIR/"
+cp "$SCRIPT_DIR/systemd/workshop-web.service" "$UNIT_DIR/"
+echo "    Copied unit files to $UNIT_DIR"
+
+systemctl --user daemon-reload
+echo "    Reloaded systemd user daemon"
+
+systemctl --user enable workshop-server workshop-web
+echo "    Enabled services"
+
+systemctl --user start workshop-server workshop-web
+echo "    Started services"
+
+echo ""
+echo "==> Status:"
+systemctl --user status workshop-server workshop-web --no-pager || true
+echo ""
+echo "Done. Use 'npm run status' to check service health."

--- a/scripts/supervise.sh
+++ b/scripts/supervise.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
+# DEPRECATED: Use systemd user units instead.
+# Install with: npm run install-services
+# Check status: npm run status
+#
+# This script is kept for reference but is no longer the recommended
+# approach. systemd provides reliable process supervision with automatic
+# restart on failure.
+#
+# Original description:
 # Workshop process supervisor — keeps server + vite alive
 # Usage: ./scripts/supervise.sh
+
+echo "[supervise] WARNING: This script is deprecated."
+echo "[supervise] Use systemd user units instead: npm run install-services"
+echo "[supervise] Continuing anyway for backwards compatibility..."
+echo ""
 
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SERVER_LOG="/tmp/workshop-server.log"

--- a/scripts/systemd/workshop-server.service
+++ b/scripts/systemd/workshop-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Workshop Express+WS Server (port 3100)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/kagura/.openclaw/workspace/workshop
+ExecStart=/home/kagura/.nvm/versions/node/v22.22.2/bin/node server/dist/index.js
+Restart=on-failure
+RestartSec=3
+Environment=NODE_ENV=production
+Environment=PORT=3100
+Environment=PATH=/home/kagura/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/workshop-web.service
+++ b/scripts/systemd/workshop-web.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Workshop Vite Dev Server (port 5173)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/kagura/.openclaw/workspace/workshop/web
+ExecStart=/home/kagura/.nvm/versions/node/v22.22.2/bin/npx vite --host 0.0.0.0
+Restart=on-failure
+RestartSec=3
+Environment=PATH=/home/kagura/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target

--- a/scripts/uninstall-services.sh
+++ b/scripts/uninstall-services.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Uninstall workshop systemd user units.
+
+set -euo pipefail
+
+UNIT_DIR="$HOME/.config/systemd/user"
+
+echo "==> Uninstalling workshop systemd user units"
+
+systemctl --user stop workshop-server workshop-web 2>/dev/null || true
+echo "    Stopped services"
+
+systemctl --user disable workshop-server workshop-web 2>/dev/null || true
+echo "    Disabled services"
+
+rm -f "$UNIT_DIR/workshop-server.service" "$UNIT_DIR/workshop-web.service"
+echo "    Removed unit files"
+
+systemctl --user daemon-reload
+echo "    Reloaded systemd user daemon"
+
+echo ""
+echo "Done. Workshop services have been removed."

--- a/scripts/workshop-status.sh
+++ b/scripts/workshop-status.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Show status and recent logs for workshop services.
+
+echo "=== Workshop Service Status ==="
+echo ""
+
+echo "--- workshop-server ---"
+systemctl --user status workshop-server --no-pager 2>/dev/null || echo "  (not installed)"
+echo ""
+
+echo "--- workshop-web ---"
+systemctl --user status workshop-web --no-pager 2>/dev/null || echo "  (not installed)"
+echo ""
+
+echo "=== Recent Logs (last 20 lines each) ==="
+echo ""
+
+echo "--- workshop-server logs ---"
+journalctl --user -u workshop-server -n 20 --no-pager 2>/dev/null || echo "  (no logs available)"
+echo ""
+
+echo "--- workshop-web logs ---"
+journalctl --user -u workshop-web -n 20 --no-pager 2>/dev/null || echo "  (no logs available)"


### PR DESCRIPTION
Closes #2

## Problem
Vite dev server (port 5173) keeps dying. The existing `scripts/supervise.sh` polling loop is fragile — it can itself die, leaving no recovery mechanism.

## Solution
Replace the polling-based supervisor with proper systemd user units:

- **`workshop-server.service`** — Express+WS server on :3100, auto-restarts on failure (3s delay)
- **`workshop-web.service`** — Vite dev server on :5173, auto-restarts on failure (3s delay)

### New scripts
| Script | Purpose |
|--------|---------|
| `npm run install-services` | Install + enable + start both units |
| `npm run uninstall-services` | Stop + disable + remove units |
| `npm run status` | Show service health + recent logs |
| `npm run logs:server` | Tail server logs |
| `npm run logs:web` | Tail web logs |

### Why systemd over supervise.sh
- systemd itself never dies (PID 1 user session)
- Built-in `Restart=on-failure` with configurable delay
- Proper logging via journalctl
- Standard Linux service management (`systemctl --user start/stop/status`)

The old `supervise.sh` is preserved with a deprecation notice for backwards compatibility.

## Testing
- Server tests: 49 pass ✅
- Web tests: 11 pass ✅