### PR TITLE
fix: use Node v24 in systemd units

### DIFF
--- a/scripts/systemd/workshop-server.service
+++ b/scripts/systemd/workshop-server.service
@@ -5,12 +5,12 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/kagura/.openclaw/workspace/workshop
-ExecStart=/home/kagura/.nvm/versions/node/v22.22.2/bin/node server/dist/index.js
+ExecStart=/home/kagura/.nvm/versions/node/v24.14.1/bin/node server/dist/index.js
 Restart=on-failure
 RestartSec=3
 Environment=NODE_ENV=production
 Environment=PORT=3100
-Environment=PATH=/home/kagura/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/home/kagura/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin
 
 [Install]
 WantedBy=default.target

--- a/scripts/systemd/workshop-web.service
+++ b/scripts/systemd/workshop-web.service
@@ -5,10 +5,10 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/kagura/.openclaw/workspace/workshop/web
-ExecStart=/home/kagura/.nvm/versions/node/v22.22.2/bin/npx vite --host 0.0.0.0
+ExecStart=/home/kagura/.nvm/versions/node/v24.14.1/bin/npx vite --host 0.0.0.0
 Restart=on-failure
 RestartSec=3
-Environment=PATH=/home/kagura/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/home/kagura/.nvm/versions/node/v24.14.1/bin:/usr/local/bin:/usr/bin:/bin
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Follow-up to #24. The systemd units originally pointed to Node v22, but better-sqlite3 was compiled against Node v24 (NODE_MODULE_VERSION 137 vs 127), causing the server to crash-loop with ERR_DLOPEN_FAILED.

Updated both units to use Node v24.14.1 which matches the native module build.

Verified: both services start and listen on their ports after this fix.