### PR TITLE
feat: runtime channel lifecycle management (delete/archive/rename)

### DIFF
--- a/server/src/__tests__/router.test.ts
+++ b/server/src/__tests__/router.test.ts
@@ -620,4 +620,128 @@ describe('router.ts - Core business logic', () => {
       expect(badges[0].unreadCount).toBe(0);
     });
   });
+
+  // ------- Channel lifecycle (delete/archive/rename) -------
+  describe('Channel lifecycle (delete/archive/rename)', () => {
+    it('delete_channel cascades correctly and broadcasts channel_deleted', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+      const db = getDb();
+
+      // Seed related data for test-channel
+      db.prepare("INSERT INTO messages (id, channel_id, sender_id, sender_name, role, content, timestamp, is_urgent) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), 0)").run('msg-1', 'test-channel', 'user', 'You', 'user', 'hello');
+      db.prepare("INSERT INTO pins (id, channel_id, type, source_id, content, updated_at) VALUES (?, ?, ?, ?, ?, datetime('now'))").run('pin-1', 'test-channel', 'custom', 'src', 'pinned');
+      db.prepare("INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)").run('notif-1', 'test-channel', 'other-channel', 'notif', 'todo_change');
+      db.prepare("INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)").run('notif-2', 'other-channel', 'test-channel', 'notif2', 'todo_change');
+      db.prepare("INSERT INTO cron_executions (id, channel_id, fired_at, agent_ids, prompt_snippet, status) VALUES (?, ?, datetime('now'), ?, ?, ?)").run('exec-1', 'test-channel', '["agent-1"]', 'snippet', 'sent');
+      db.prepare("INSERT INTO north_stars (id, scope, content, updated_at) VALUES (?, ?, ?, datetime('now'))").run('ns-1', 'test-channel', 'goal');
+      db.prepare("INSERT INTO todo_items (id, section, content, status, assigned_channel, assigned_agent, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))").run('todo-1', 'backlog', 'task', 'pending', 'test-channel', null);
+
+      ctx.clearSent();
+      (ctx.router as any).handleDeleteChannel('test-channel');
+
+      // Verify channel row is gone
+      expect(db.prepare('SELECT * FROM channels WHERE id = ?').get('test-channel')).toBeUndefined();
+
+      // Verify cascaded deletes
+      expect(db.prepare('SELECT * FROM channel_agents WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
+      expect(db.prepare('SELECT * FROM messages WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
+      expect(db.prepare('SELECT * FROM pins WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
+      expect(db.prepare("SELECT * FROM notifications WHERE source_channel_id = 'test-channel' OR target_channel_id = 'test-channel'").all()).toHaveLength(0);
+      expect(db.prepare('SELECT * FROM cron_executions WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
+      expect(db.prepare("SELECT * FROM north_stars WHERE scope = 'test-channel'").all()).toHaveLength(0);
+
+      // Todo assignment cleared but todo still exists
+      const todo = db.prepare('SELECT * FROM todo_items WHERE id = ?').get('todo-1') as any;
+      expect(todo).toBeTruthy();
+      expect(todo.assigned_channel).toBeNull();
+
+      // Broadcast
+      const deleted = ctx.sentOfType('channel_deleted');
+      expect(deleted).toHaveLength(1);
+      expect(deleted[0].channelId).toBe('test-channel');
+    });
+
+    it('delete_channel stops cron', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      const mockCronManager = { stopChannel: vi.fn() };
+      (ctx.router as any).cronManager = mockCronManager;
+
+      (ctx.router as any).handleDeleteChannel('test-channel');
+
+      expect(mockCronManager.stopChannel).toHaveBeenCalledWith('test-channel');
+    });
+
+    it('archive_channel toggles status and broadcasts channel_updated', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+      const db = getDb();
+
+      // Initially active
+      const before = db.prepare('SELECT status FROM channels WHERE id = ?').get('test-channel') as any;
+      expect(before.status).toBe('active');
+
+      ctx.clearSent();
+      (ctx.router as any).handleArchiveChannel('test-channel');
+
+      const after = db.prepare('SELECT status FROM channels WHERE id = ?').get('test-channel') as any;
+      expect(after.status).toBe('archived');
+
+      const updated = ctx.sentOfType('channel_updated');
+      expect(updated).toHaveLength(1);
+      expect(updated[0].channel.status).toBe('archived');
+
+      // Toggle back
+      ctx.clearSent();
+      (ctx.router as any).handleArchiveChannel('test-channel');
+
+      const restored = db.prepare('SELECT status FROM channels WHERE id = ?').get('test-channel') as any;
+      expect(restored.status).toBe('active');
+    });
+
+    it('archive_channel stops cron when archiving', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      const mockCronManager = { stopChannel: vi.fn(), syncChannel: vi.fn() };
+      (ctx.router as any).cronManager = mockCronManager;
+
+      (ctx.router as any).handleArchiveChannel('test-channel');
+
+      expect(mockCronManager.stopChannel).toHaveBeenCalledWith('test-channel');
+    });
+
+    it('rename_channel updates name and broadcasts', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+      const db = getDb();
+
+      ctx.clearSent();
+      (ctx.router as any).handleRenameChannel('test-channel', 'Renamed Channel');
+
+      const row = db.prepare('SELECT name FROM channels WHERE id = ?').get('test-channel') as any;
+      expect(row.name).toBe('Renamed Channel');
+
+      const updated = ctx.sentOfType('channel_updated');
+      expect(updated).toHaveLength(1);
+      expect(updated[0].channel.name).toBe('Renamed Channel');
+    });
+
+    it('archived channel: handleSendMessage does not forward to gateway', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+      const db = getDb();
+      const gateway = { sendChat: vi.fn() };
+      (ctx.router as any).gateway = gateway;
+
+      // Archive the channel
+      db.prepare("UPDATE channels SET status = 'archived' WHERE id = ?").run('test-channel');
+
+      (ctx.router as any).handleSendMessage('test-channel', 'hello archived');
+
+      // Message should be stored
+      const msgs = db.prepare('SELECT * FROM messages WHERE channel_id = ?').all('test-channel') as any[];
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].content).toBe('hello archived');
+
+      // But gateway should NOT be called
+      expect(gateway.sendChat).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -172,6 +172,16 @@ export class ChannelCronManager {
     }));
   }
 
+  /** Stop and remove the cron task for a specific channel. */
+  stopChannel(channelId: string): void {
+    const existing = this.tasks.get(channelId);
+    if (existing) {
+      existing.stop();
+      this.tasks.delete(channelId);
+      console.log(`[cron] stopped channel=${channelId}`);
+    }
+  }
+
   /** Stop all cron tasks (for graceful shutdown). */
   stopAll(): void {
     for (const [channelId, task] of this.tasks) {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -190,6 +190,15 @@ export class Router {
       case 'remove_agent':
         this.handleRemoveAgent(ws, msg.id);
         break;
+      case 'delete_channel':
+        this.handleDeleteChannel(msg.channelId);
+        break;
+      case 'archive_channel':
+        this.handleArchiveChannel(msg.channelId);
+        break;
+      case 'rename_channel':
+        this.handleRenameChannel(msg.channelId, msg.name);
+        break;
       default:
         this.sendTo(ws, { type: 'error', message: 'Unknown message type' });
     }
@@ -209,6 +218,13 @@ export class Router {
     const msg = this.storeMessage(channelId, 'user', 'You', 'user', content, isUrgent);
     console.log(`[msg] user → channel=${channelId}: "${content.slice(0, 80)}"`);
     this.broadcast({ type: 'message', channelId, message: msg });
+
+    // Skip forwarding to gateway if channel is archived (still stored for history)
+    const channelRow = getDb().prepare('SELECT status FROM channels WHERE id = ?').get(channelId) as any;
+    if (channelRow?.status === 'archived') {
+      console.log(`[msg] channel=${channelId} is archived, skipping gateway forward`);
+      return;
+    }
 
     if (!this.gateway) {
       console.warn(`[msg] no gateway connection`);
@@ -264,6 +280,111 @@ export class Router {
 
       this.gateway.sendChat(sendContent, channelId, agent_id);
     }
+  }
+
+  private handleDeleteChannel(channelId: string): void {
+    const db = getDb();
+
+    const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
+    if (!row) return;
+
+    // Cascade delete related data
+    db.prepare('DELETE FROM channel_agents WHERE channel_id = ?').run(channelId);
+    db.prepare('DELETE FROM messages WHERE channel_id = ?').run(channelId);
+    db.prepare('DELETE FROM pins WHERE channel_id = ?').run(channelId);
+    db.prepare('DELETE FROM notifications WHERE source_channel_id = ? OR target_channel_id = ?').run(channelId, channelId);
+    db.prepare('DELETE FROM cron_executions WHERE channel_id = ?').run(channelId);
+    db.prepare('DELETE FROM north_stars WHERE scope = ?').run(channelId);
+
+    // Clear todo assignments (set to null, don't delete todos)
+    db.prepare('UPDATE todo_items SET assigned_channel = NULL WHERE assigned_channel = ?').run(channelId);
+
+    // Stop cron
+    if (this.cronManager) {
+      this.cronManager.stopChannel(channelId);
+    }
+
+    // Delete channel row
+    db.prepare('DELETE FROM channels WHERE id = ?').run(channelId);
+
+    this.broadcast({ type: 'channel_deleted', channelId });
+  }
+
+  private handleArchiveChannel(channelId: string): void {
+    const db = getDb();
+
+    const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
+    if (!row) return;
+
+    const newStatus = row.status === 'archived' ? 'active' : 'archived';
+    db.prepare('UPDATE channels SET status = ? WHERE id = ?').run(newStatus, channelId);
+
+    if (newStatus === 'archived' && this.cronManager) {
+      this.cronManager.stopChannel(channelId);
+    }
+
+    if (newStatus === 'active' && this.cronManager) {
+      // Re-sync cron if channel has cron settings
+      const updated = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
+      if (updated.cron_enabled && updated.cron_schedule) {
+        const agents = db.prepare(
+          'SELECT agent_id, require_mention FROM channel_agents WHERE channel_id = ?'
+        ).all(channelId) as { agent_id: string; require_mention: number }[];
+        const channel: Channel = {
+          id: updated.id, name: updated.name,
+          agents: agents.map(a => a.agent_id),
+          agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
+          createdAt: updated.created_at, status: updated.status,
+          type: updated.type ?? 'project', positioning: updated.positioning ?? '',
+          guidelines: updated.guidelines ?? '', northStar: updated.north_star ?? '',
+          todoSection: updated.todo_section ?? null, cronSchedule: updated.cron_schedule ?? null,
+          cronEnabled: !!updated.cron_enabled,
+        };
+        this.cronManager.syncChannel(channel);
+      }
+    }
+
+    // Broadcast channel_updated with the full channel
+    const updated = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
+    const agents = db.prepare(
+      'SELECT agent_id, require_mention FROM channel_agents WHERE channel_id = ?'
+    ).all(channelId) as { agent_id: string; require_mention: number }[];
+    const channel: Channel = {
+      id: updated.id, name: updated.name,
+      agents: agents.map(a => a.agent_id),
+      agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
+      createdAt: updated.created_at, status: updated.status,
+      type: updated.type ?? 'project', positioning: updated.positioning ?? '',
+      guidelines: updated.guidelines ?? '', northStar: updated.north_star ?? '',
+      todoSection: updated.todo_section ?? null, cronSchedule: updated.cron_schedule ?? null,
+      cronEnabled: !!updated.cron_enabled,
+    };
+    this.broadcast({ type: 'channel_updated', channel });
+  }
+
+  private handleRenameChannel(channelId: string, name: string): void {
+    const db = getDb();
+
+    const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
+    if (!row) return;
+
+    db.prepare('UPDATE channels SET name = ? WHERE id = ?').run(name, channelId);
+
+    // Broadcast channel_updated
+    const agents = db.prepare(
+      'SELECT agent_id, require_mention FROM channel_agents WHERE channel_id = ?'
+    ).all(channelId) as { agent_id: string; require_mention: number }[];
+    const channel: Channel = {
+      id: row.id, name,
+      agents: agents.map(a => a.agent_id),
+      agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
+      createdAt: row.created_at, status: row.status,
+      type: row.type ?? 'project', positioning: row.positioning ?? '',
+      guidelines: row.guidelines ?? '', northStar: row.north_star ?? '',
+      todoSection: row.todo_section ?? null, cronSchedule: row.cron_schedule ?? null,
+      cronEnabled: !!row.cron_enabled,
+    };
+    this.broadcast({ type: 'channel_updated', channel });
   }
 
   private handleListChannels(ws: WebSocket): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -77,6 +77,9 @@ export type ClientMessage =
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
   | { type: 'notification_mark_read'; channelId: string }
+  | { type: 'delete_channel'; channelId: string }
+  | { type: 'archive_channel'; channelId: string }
+  | { type: 'rename_channel'; channelId: string; name: string }
   | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
   | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
   | { type: 'remove_agent'; id: string };
@@ -105,6 +108,7 @@ export type ServerMessage =
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
   | { type: 'notification_badge'; channelId: string; unreadCount: number }
+  | { type: 'channel_deleted'; channelId: string }
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -74,6 +74,10 @@ export default function App() {
       case 'channel_meta_updated':
         setChannels((prev) => prev.map((c) => c.id === msg.channel.id ? msg.channel : c));
         break;
+      case 'channel_deleted':
+        setChannels((prev) => prev.filter((c) => c.id !== msg.channelId));
+        setActiveChannelId((prev) => prev === msg.channelId ? null : prev);
+        break;
       case 'todo_list':
         setTodoItems(msg.items);
         break;
@@ -189,6 +193,18 @@ export default function App() {
     send({ type: 'remove_agent', id });
   };
 
+  const handleDeleteChannel = (channelId: string) => {
+    send({ type: 'delete_channel', channelId });
+  };
+
+  const handleArchiveChannel = (channelId: string) => {
+    send({ type: 'archive_channel', channelId });
+  };
+
+  const handleRenameChannel = (channelId: string, name: string) => {
+    send({ type: 'rename_channel', channelId, name });
+  };
+
   // Request pins when active channel changes
   useEffect(() => {
     if (activeChannelId && connected) {
@@ -285,6 +301,9 @@ export default function App() {
             setShowChannelSettings(false);
           }}
           onPatrolConfigSave={handlePatrolConfigSet}
+          onDeleteChannel={handleDeleteChannel}
+          onArchiveChannel={handleArchiveChannel}
+          onRenameChannel={handleRenameChannel}
         />
       )}
       {showCronDashboard && (

--- a/web/src/components/ChannelSettingsPanel.tsx
+++ b/web/src/components/ChannelSettingsPanel.tsx
@@ -14,6 +14,9 @@ interface ChannelSettingsPanelProps {
   onCronTrigger?: (channelId: string) => void;
   cronHistory?: CronExecution[];
   onPatrolConfigSave?: (config: Partial<PatrolConfig>) => void;
+  onDeleteChannel?: (channelId: string) => void;
+  onArchiveChannel?: (channelId: string) => void;
+  onRenameChannel?: (channelId: string, name: string) => void;
 }
 
 const CHANNEL_TYPES: { value: ChannelType; label: string }[] = [
@@ -22,7 +25,7 @@ const CHANNEL_TYPES: { value: ChannelType; label: string }[] = [
   { value: 'meta', label: 'Meta' },
 ];
 
-export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose, onSave, onCronTrigger, cronHistory, onPatrolConfigSave }: ChannelSettingsPanelProps) {
+export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose, onSave, onCronTrigger, cronHistory, onPatrolConfigSave, onDeleteChannel, onArchiveChannel, onRenameChannel }: ChannelSettingsPanelProps) {
   const [type, setType] = useState<ChannelType>(channel.type);
   const [positioning, setPositioning] = useState(channel.positioning);
   const [guidelines, setGuidelines] = useState(channel.guidelines);
@@ -30,6 +33,9 @@ export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose,
   const [todoSection, setTodoSection] = useState(channel.todoSection ?? '');
   const [cronSchedule, setCronSchedule] = useState(channel.cronSchedule ?? '');
   const [cronEnabled, setCronEnabled] = useState(channel.cronEnabled);
+  const [renameName, setRenameName] = useState(channel.name);
+  const [deleteConfirm, setDeleteConfirm] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // Patrol state
   const [patrolSchedule, setPatrolSchedule] = useState(patrolConfig?.schedule ?? '0 */3 * * *');
@@ -241,6 +247,88 @@ export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose,
               </div>
             </div>
           )}
+
+          {/* Channel Management */}
+          <div className="space-y-3 pt-3 border-t border-border">
+            <Label className="text-xs uppercase tracking-wide text-muted-foreground">Channel Management</Label>
+
+            {/* Rename */}
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Rename Channel</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={renameName}
+                  onChange={(e) => setRenameName(e.target.value)}
+                  className="bg-muted text-sm flex-1"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  disabled={!renameName.trim() || renameName === channel.name}
+                  onClick={() => {
+                    onRenameChannel?.(channel.id, renameName.trim());
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+
+            {/* Archive / Unarchive */}
+            <Button
+              variant="outline"
+              size="sm"
+              className={`text-xs w-full ${channel.status === 'archived' ? 'text-green-400 border-green-400/40 hover:bg-green-400/10' : 'text-blue-400 border-blue-400/40 hover:bg-blue-400/10'}`}
+              onClick={() => onArchiveChannel?.(channel.id)}
+            >
+              {channel.status === 'archived' ? 'Unarchive Channel' : 'Archive Channel'}
+            </Button>
+
+            {/* Delete */}
+            {!showDeleteConfirm ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs w-full text-red-400 border-red-400/40 hover:bg-red-400/10"
+                onClick={() => setShowDeleteConfirm(true)}
+              >
+                Delete Channel
+              </Button>
+            ) : (
+              <div className="space-y-2 p-2 rounded border border-red-400/40 bg-red-400/5">
+                <p className="text-xs text-red-400">Type <strong>{channel.name}</strong> to confirm deletion:</p>
+                <Input
+                  value={deleteConfirm}
+                  onChange={(e) => setDeleteConfirm(e.target.value)}
+                  placeholder={channel.name}
+                  className="bg-muted text-sm"
+                />
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs flex-1"
+                    onClick={() => { setShowDeleteConfirm(false); setDeleteConfirm(''); }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs flex-1 text-red-400 border-red-400/40 hover:bg-red-400/10"
+                    disabled={deleteConfirm !== channel.name}
+                    onClick={() => {
+                      onDeleteChannel?.(channel.id);
+                      onClose();
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="p-4 border-t border-border flex justify-end gap-2">

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -18,6 +18,10 @@ interface SidebarProps {
 
 export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard }: SidebarProps) {
   const [showDialog, setShowDialog] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  const activeChannels = channels.filter((c) => c.status !== 'archived');
+  const archivedChannels = channels.filter((c) => c.status === 'archived');
 
   return (
     <div className="w-60 bg-card border-r border-border flex flex-col">
@@ -42,12 +46,12 @@ export function Sidebar({ channels, agents, activeChannelId, notificationBadges,
               +
             </button>
           </div>
-          {channels.length === 0 && (
+          {activeChannels.length === 0 && archivedChannels.length === 0 && (
             <div className="px-3 py-2 text-muted-foreground text-[13px]">
               No channels yet
             </div>
           )}
-          {channels.map((channel) => (
+          {activeChannels.map((channel) => (
             <div
               key={channel.id}
               className={cn(
@@ -77,6 +81,38 @@ export function Sidebar({ channels, agents, activeChannelId, notificationBadges,
               </button>
             </div>
           ))}
+
+          {/* Archived channels section */}
+          {archivedChannels.length > 0 && (
+            <div className="mt-2">
+              <button
+                className="flex items-center gap-1 px-3 py-1.5 w-full text-left uppercase tracking-wide text-xs font-semibold text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
+                onClick={() => setShowArchived((v) => !v)}
+              >
+                <span className="text-[10px]">{showArchived ? '\u25BC' : '\u25B6'}</span>
+                Archived ({archivedChannels.length})
+              </button>
+              {showArchived && archivedChannels.map((channel) => (
+                <div
+                  key={channel.id}
+                  className={cn(
+                    "group px-3 py-2 rounded cursor-pointer text-muted-foreground/50 hover:bg-accent hover:text-muted-foreground text-sm flex items-center gap-1.5 before:content-['#'] before:text-muted-foreground/30 before:font-semibold",
+                    channel.id === activeChannelId && 'bg-accent text-muted-foreground'
+                  )}
+                  onClick={() => onSelectChannel(channel.id)}
+                >
+                  <span className="flex-1 truncate">{channel.name}</span>
+                  <button
+                    className="shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground/50 hover:text-foreground cursor-pointer text-xs"
+                    onClick={(e) => { e.stopPropagation(); onOpenSettings(channel.id); }}
+                    title="Channel settings"
+                  >
+                    &#9881;
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </ScrollArea>
       {showDialog && (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -98,6 +98,7 @@ export type ServerMessage =
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'notification'; notification: Notification }
   | { type: 'notification_badge'; channelId: string; unreadCount: number }
+  | { type: 'channel_deleted'; channelId: string }
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }
@@ -127,6 +128,9 @@ export type ClientMessage =
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
   | { type: 'notification_mark_read'; channelId: string }
+  | { type: 'delete_channel'; channelId: string }
+  | { type: 'archive_channel'; channelId: string }
+  | { type: 'rename_channel'; channelId: string; name: string }
   | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
   | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
   | { type: 'remove_agent'; id: string };


### PR DESCRIPTION
## What

Adds full runtime channel management — delete, archive/unarchive, and rename channels without server restart.

This closes the last gap in making Workshop's channel management fully dynamic. Previously channels could only be created and configured at runtime; now they can be deleted, archived, and renamed too.

### Design Principle
> Channel/room management must be runtime-dynamic — no restart required.

## Changes

### Server
- 3 new WebSocket message types: delete_channel, archive_channel, rename_channel
- 1 new broadcast: channel_deleted
- Delete cascade: channel_agents, messages, pins, notifications, cron_executions, north_stars, todo assignment cleanup
- Archive toggle: active ↔ archived, stops/restarts cron, archived channels blocked from gateway
- Rename: updates name, broadcasts channel_updated
- Cron: new stopChannel() method

### Frontend
- ChannelSettingsPanel: Channel Management section (rename, archive/unarchive, delete with confirmation)
- Sidebar: archived channels in collapsible dimmed section

### Tests
- 6 new server tests (55 total, all passing)