### PR TITLE
feat: agent-to-agent direct messaging

### DIFF
--- a/server/src/__tests__/dm.test.ts
+++ b/server/src/__tests__/dm.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestContext, seedTestData, teardownTestContext } from './helpers.js';
+import { getDb } from '../db.js';
+
+describe('Direct Messages', () => {
+  let ctx: ReturnType<typeof createTestContext>;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+    seedTestData(ctx.db);
+    ctx.router.registerAgent({ id: 'agent-1', name: 'Alice', status: 'online' });
+    ctx.router.registerAgent({ id: 'agent-2', name: 'Bob', status: 'online' });
+    // Add client so broadcast works
+    (ctx.router as any).clients.add(ctx.mockWs);
+  });
+
+  afterEach(() => {
+    teardownTestContext();
+  });
+
+  describe('send_dm', () => {
+    it('stores a DM in the database and broadcasts dm_message', () => {
+      ctx.clearSent();
+      (ctx.router as any).handleSendDm(ctx.mockWs, 'agent-1', 'Hello Alice!');
+
+      // Check database
+      const db = getDb();
+      const rows = db.prepare('SELECT * FROM direct_messages').all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].from_id).toBe('user');
+      expect(rows[0].to_id).toBe('agent-1');
+      expect(rows[0].content).toBe('Hello Alice!');
+      expect(rows[0].read).toBe(0);
+
+      // Check broadcast
+      const dmMessages = ctx.sentOfType('dm_message');
+      expect(dmMessages).toHaveLength(1);
+      expect(dmMessages[0].message.fromId).toBe('user');
+      expect(dmMessages[0].message.toId).toBe('agent-1');
+      expect(dmMessages[0].message.content).toBe('Hello Alice!');
+      expect(dmMessages[0].message.read).toBe(false);
+    });
+
+    it('stores multiple DMs to different agents', () => {
+      (ctx.router as any).handleSendDm(ctx.mockWs, 'agent-1', 'Hello Alice!');
+      (ctx.router as any).handleSendDm(ctx.mockWs, 'agent-2', 'Hello Bob!');
+
+      const db = getDb();
+      const rows = db.prepare('SELECT * FROM direct_messages ORDER BY timestamp ASC').all() as any[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0].to_id).toBe('agent-1');
+      expect(rows[1].to_id).toBe('agent-2');
+    });
+  });
+
+  describe('list_dms', () => {
+    it('returns messages between user and a specific agent', () => {
+      // Insert some DMs
+      const db = getDb();
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-1', 'user', 'agent-1', 'Hello', '2024-01-01T00:00:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-2', 'agent-1', 'user', 'Hi back', '2024-01-01T00:01:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-3', 'user', 'agent-2', 'Different agent', '2024-01-01T00:02:00Z', 0);
+
+      ctx.clearSent();
+      (ctx.router as any).handleListDms(ctx.mockWs, 'agent-1');
+
+      const dmList = ctx.sentOfType('dm_list');
+      expect(dmList).toHaveLength(1);
+      expect(dmList[0].withId).toBe('agent-1');
+      expect(dmList[0].messages).toHaveLength(2);
+      // Should be ordered by timestamp ASC
+      expect(dmList[0].messages[0].content).toBe('Hello');
+      expect(dmList[0].messages[1].content).toBe('Hi back');
+    });
+
+    it('respects limit parameter', () => {
+      const db = getDb();
+      for (let i = 0; i < 5; i++) {
+        db.prepare(
+          "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+        ).run(`dm-${i}`, 'user', 'agent-1', `msg ${i}`, `2024-01-01T00:0${i}:00Z`, 0);
+      }
+
+      ctx.clearSent();
+      (ctx.router as any).handleListDms(ctx.mockWs, 'agent-1', 2);
+
+      const dmList = ctx.sentOfType('dm_list');
+      expect(dmList[0].messages).toHaveLength(2);
+    });
+
+    it('respects before parameter for pagination', () => {
+      const db = getDb();
+      for (let i = 0; i < 5; i++) {
+        db.prepare(
+          "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+        ).run(`dm-${i}`, 'user', 'agent-1', `msg ${i}`, `2024-01-01T00:0${i}:00Z`, 0);
+      }
+
+      ctx.clearSent();
+      (ctx.router as any).handleListDms(ctx.mockWs, 'agent-1', 100, '2024-01-01T00:03:00Z');
+
+      const dmList = ctx.sentOfType('dm_list');
+      // Should only include messages before the specified timestamp
+      expect(dmList[0].messages).toHaveLength(3);
+      expect(dmList[0].messages[2].content).toBe('msg 2');
+    });
+  });
+
+  describe('dm_mark_read', () => {
+    it('marks incoming DMs as read', () => {
+      const db = getDb();
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-1', 'agent-1', 'user', 'Hello', '2024-01-01T00:00:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-2', 'agent-1', 'user', 'Are you there?', '2024-01-01T00:01:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-3', 'agent-2', 'user', 'From other agent', '2024-01-01T00:02:00Z', 0);
+
+      ctx.clearSent();
+      (ctx.router as any).handleDmMarkRead(ctx.mockWs, 'agent-1');
+
+      // agent-1's messages should be read
+      const dm1 = db.prepare('SELECT read FROM direct_messages WHERE id = ?').get('dm-1') as any;
+      const dm2 = db.prepare('SELECT read FROM direct_messages WHERE id = ?').get('dm-2') as any;
+      expect(dm1.read).toBe(1);
+      expect(dm2.read).toBe(1);
+
+      // agent-2's message should still be unread
+      const dm3 = db.prepare('SELECT read FROM direct_messages WHERE id = ?').get('dm-3') as any;
+      expect(dm3.read).toBe(0);
+    });
+
+    it('sends updated unread counts', () => {
+      const db = getDb();
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-1', 'agent-1', 'user', 'Hello', '2024-01-01T00:00:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-2', 'agent-2', 'user', 'Hi', '2024-01-01T00:01:00Z', 0);
+
+      ctx.clearSent();
+      (ctx.router as any).handleDmMarkRead(ctx.mockWs, 'agent-1');
+
+      const unread = ctx.sentOfType('dm_unread');
+      expect(unread).toHaveLength(1);
+      // Only agent-2 should have unread
+      expect(unread[0].counts['agent-1']).toBeUndefined();
+      expect(unread[0].counts['agent-2']).toBe(1);
+    });
+  });
+
+  describe('dm_conversations', () => {
+    it('lists all DM conversations with last message and unread count', () => {
+      const db = getDb();
+      // Conversation with agent-1
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-1', 'user', 'agent-1', 'Hello Alice', '2024-01-01T00:00:00Z', 1);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-2', 'agent-1', 'user', 'Hi there', '2024-01-01T00:01:00Z', 0);
+      // Conversation with agent-2
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-3', 'user', 'agent-2', 'Hey Bob', '2024-01-01T00:02:00Z', 1);
+
+      ctx.clearSent();
+      (ctx.router as any).handleDmConversations(ctx.mockWs);
+
+      const convos = ctx.sentOfType('dm_conversations');
+      expect(convos).toHaveLength(1);
+      expect(convos[0].conversations).toHaveLength(2);
+
+      // Ordered by last timestamp DESC
+      const first = convos[0].conversations[0];
+      expect(first.partnerId).toBe('agent-2');
+      expect(first.partnerName).toBe('Bob');
+      expect(first.lastMessage).toBe('Hey Bob');
+      expect(first.unreadCount).toBe(0);
+
+      const second = convos[0].conversations[1];
+      expect(second.partnerId).toBe('agent-1');
+      expect(second.partnerName).toBe('Alice');
+      expect(second.lastMessage).toBe('Hi there');
+      expect(second.unreadCount).toBe(1);
+    });
+
+    it('returns empty array when no conversations exist', () => {
+      ctx.clearSent();
+      (ctx.router as any).handleDmConversations(ctx.mockWs);
+
+      const convos = ctx.sentOfType('dm_conversations');
+      expect(convos).toHaveLength(1);
+      expect(convos[0].conversations).toHaveLength(0);
+    });
+  });
+
+  describe('sendDmUnread', () => {
+    it('sends unread counts grouped by sender', () => {
+      const db = getDb();
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-1', 'agent-1', 'user', 'Hello', '2024-01-01T00:00:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-2', 'agent-1', 'user', 'Another', '2024-01-01T00:01:00Z', 0);
+      db.prepare(
+        "INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run('dm-3', 'agent-2', 'user', 'From Bob', '2024-01-01T00:02:00Z', 0);
+
+      ctx.clearSent();
+      (ctx.router as any).sendDmUnread(ctx.mockWs);
+
+      const unread = ctx.sentOfType('dm_unread');
+      expect(unread).toHaveLength(1);
+      expect(unread[0].counts['agent-1']).toBe(2);
+      expect(unread[0].counts['agent-2']).toBe(1);
+    });
+  });
+
+  describe('direct_messages table', () => {
+    it('exists with correct columns', () => {
+      const db = getDb();
+      const cols = db.prepare('PRAGMA table_info(direct_messages)').all() as { name: string }[];
+      const colNames = cols.map(c => c.name);
+      expect(colNames).toContain('id');
+      expect(colNames).toContain('from_id');
+      expect(colNames).toContain('to_id');
+      expect(colNames).toContain('content');
+      expect(colNames).toContain('timestamp');
+      expect(colNames).toContain('read');
+    });
+  });
+});

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -187,6 +187,19 @@ function initSchema(): void {
   if (!hasColumn(d, 'messages', 'is_urgent')) {
     d.exec("ALTER TABLE messages ADD COLUMN is_urgent INTEGER NOT NULL DEFAULT 0");
   }
+
+  // Direct messages
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS direct_messages (
+      id TEXT PRIMARY KEY,
+      from_id TEXT NOT NULL,
+      to_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      read INTEGER DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_dm_participants ON direct_messages(from_id, to_id);
+  `);
 }
 
 export function close(): void {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -4,7 +4,7 @@ import { getDb } from './db.js';
 import { GatewayConnection } from './gateway.js';
 import { ChannelCronManager } from './cron.js';
 import { getPatrolConfig, setPatrolConfig } from './patrol.js';
-import type { ClientMessage, ServerMessage, Message, Channel, Agent, TodoItem, CronExecution, NorthStar, Pin, PatrolConfig, Notification, NotificationTrigger } from './types.js';
+import type { ClientMessage, ServerMessage, Message, Channel, Agent, TodoItem, CronExecution, NorthStar, Pin, PatrolConfig, Notification, NotificationTrigger, DirectMessage, DmConversation } from './types.js';
 
 /**
  * Router — bridges frontend WebSocket clients with a single shared OpenClaw Gateway connection.
@@ -29,6 +29,7 @@ export class Router {
     this.sendAllChannelHistory(ws);
     this.sendAllNotificationBadges(ws);
     this.handlePatrolConfigGet(ws);
+    this.sendDmUnread(ws);
 
     ws.on('message', (raw) => {
       try {
@@ -198,6 +199,18 @@ export class Router {
         break;
       case 'rename_channel':
         this.handleRenameChannel(msg.channelId, msg.name);
+        break;
+      case 'send_dm':
+        this.handleSendDm(ws, msg.toId, msg.content);
+        break;
+      case 'list_dms':
+        this.handleListDms(ws, msg.withId, msg.limit, msg.before);
+        break;
+      case 'dm_mark_read':
+        this.handleDmMarkRead(ws, msg.withId);
+        break;
+      case 'dm_conversations':
+        this.handleDmConversations(ws);
         break;
       default:
         this.sendTo(ws, { type: 'error', message: 'Unknown message type' });
@@ -1100,6 +1113,121 @@ export class Router {
       };
       this.broadcast({ type: 'channel_updated', channel });
     }
+  }
+
+  // --- DM handlers ---
+
+  private handleSendDm(ws: WebSocket, toId: string, content: string): void {
+    const db = getDb();
+    const id = uuid();
+    const timestamp = new Date().toISOString();
+    const fromId = 'user'; // The current user (frontend client)
+
+    db.prepare(
+      'INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, 0)'
+    ).run(id, fromId, toId, content, timestamp);
+
+    const message: DirectMessage = { id, fromId, toId, content, timestamp, read: false };
+    this.broadcast({ type: 'dm_message', message });
+  }
+
+  private handleListDms(ws: WebSocket, withId: string, limit?: number, before?: string): void {
+    const db = getDb();
+    const max = limit ?? 100;
+
+    let rows: any[];
+    if (before) {
+      rows = db.prepare(
+        `SELECT * FROM direct_messages
+         WHERE ((from_id = 'user' AND to_id = ?) OR (from_id = ? AND to_id = 'user'))
+           AND timestamp < ?
+         ORDER BY timestamp DESC LIMIT ?`
+      ).all(withId, withId, before, max);
+    } else {
+      rows = db.prepare(
+        `SELECT * FROM direct_messages
+         WHERE (from_id = 'user' AND to_id = ?) OR (from_id = ? AND to_id = 'user')
+         ORDER BY timestamp DESC LIMIT ?`
+      ).all(withId, withId, max);
+    }
+
+    const messages: DirectMessage[] = rows.reverse().map((r: any) => ({
+      id: r.id,
+      fromId: r.from_id,
+      toId: r.to_id,
+      content: r.content,
+      timestamp: r.timestamp,
+      read: !!r.read,
+    }));
+
+    this.sendTo(ws, { type: 'dm_list', withId, messages });
+  }
+
+  private handleDmMarkRead(ws: WebSocket, withId: string): void {
+    const db = getDb();
+    db.prepare(
+      "UPDATE direct_messages SET read = 1 WHERE from_id = ? AND to_id = 'user' AND read = 0"
+    ).run(withId);
+
+    // Send updated unread counts
+    this.sendDmUnread(ws);
+  }
+
+  private handleDmConversations(ws: WebSocket): void {
+    const db = getDb();
+
+    // Find all unique DM partners
+    const rows = db.prepare(`
+      SELECT partner_id, MAX(timestamp) as last_ts FROM (
+        SELECT to_id as partner_id, timestamp FROM direct_messages WHERE from_id = 'user'
+        UNION ALL
+        SELECT from_id as partner_id, timestamp FROM direct_messages WHERE to_id = 'user'
+      ) GROUP BY partner_id ORDER BY last_ts DESC
+    `).all() as any[];
+
+    const conversations: DmConversation[] = rows.map((r: any) => {
+      const partnerId = r.partner_id;
+
+      // Get agent name
+      const agent = db.prepare('SELECT name FROM agents WHERE id = ?').get(partnerId) as any;
+      const partnerName = agent?.name ?? partnerId;
+
+      // Get last message
+      const lastMsg = db.prepare(
+        `SELECT content, timestamp FROM direct_messages
+         WHERE (from_id = 'user' AND to_id = ?) OR (from_id = ? AND to_id = 'user')
+         ORDER BY timestamp DESC LIMIT 1`
+      ).get(partnerId, partnerId) as any;
+
+      // Count unread
+      const unread = db.prepare(
+        "SELECT COUNT(*) as cnt FROM direct_messages WHERE from_id = ? AND to_id = 'user' AND read = 0"
+      ).get(partnerId) as any;
+
+      return {
+        partnerId,
+        partnerName,
+        lastMessage: lastMsg?.content ?? '',
+        lastTimestamp: lastMsg?.timestamp ?? r.last_ts,
+        unreadCount: unread?.cnt ?? 0,
+      };
+    });
+
+    this.sendTo(ws, { type: 'dm_conversations', conversations });
+  }
+
+  private sendDmUnread(ws: WebSocket): void {
+    const db = getDb();
+    const rows = db.prepare(
+      "SELECT from_id, COUNT(*) as cnt FROM direct_messages WHERE to_id = 'user' AND read = 0 GROUP BY from_id"
+    ).all() as any[];
+
+    const counts: Record<string, number> = {};
+    for (const r of rows) {
+      counts[r.from_id] = r.cnt;
+    }
+
+    this.sendTo(ws, { type: 'dm_unread', counts });
   }
 
   private broadcast(msg: ServerMessage): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -52,6 +52,23 @@ export interface Message {
   isUrgent: boolean;
 }
 
+export interface DirectMessage {
+  id: string;
+  fromId: string;
+  toId: string;
+  content: string;
+  timestamp: string;
+  read: boolean;
+}
+
+export interface DmConversation {
+  partnerId: string;
+  partnerName: string;
+  lastMessage: string;
+  lastTimestamp: string;
+  unreadCount: number;
+}
+
 // WebSocket protocol: client → server
 export type ClientMessage =
   | { type: 'send_message'; channelId: string; content: string }
@@ -82,7 +99,11 @@ export type ClientMessage =
   | { type: 'rename_channel'; channelId: string; name: string }
   | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
   | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
-  | { type: 'remove_agent'; id: string };
+  | { type: 'remove_agent'; id: string }
+  | { type: 'send_dm'; toId: string; content: string }
+  | { type: 'list_dms'; withId: string; limit?: number; before?: string }
+  | { type: 'dm_mark_read'; withId: string }
+  | { type: 'dm_conversations' };
 
 // WebSocket protocol: server → client
 export type ServerMessage =
@@ -112,6 +133,10 @@ export type ServerMessage =
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }
+  | { type: 'dm_message'; message: DirectMessage }
+  | { type: 'dm_list'; withId: string; messages: DirectMessage[] }
+  | { type: 'dm_conversations'; conversations: DmConversation[] }
+  | { type: 'dm_unread'; counts: Record<string, number> }
   | { type: 'error'; message: string };
 
 export interface NorthStar {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,18 @@
 import { useState, useCallback, useEffect } from 'react';
 import { Sidebar } from './components/Sidebar';
 import { ChatView } from './components/ChatView';
+import { DmView } from './components/DmView';
 import { AgentList } from './components/AgentList';
 import { CreateChannelDialog } from './components/CreateChannelDialog';
 import { ChannelSettingsPanel } from './components/ChannelSettingsPanel';
 import { TodoPanel } from './components/TodoPanel';
 import { CronDashboard } from './components/CronDashboard';
 import { useWebSocket } from './hooks/useWebSocket';
-import type { Channel, Agent, Message, ServerMessage, TodoItem, NorthStar, Pin, PatrolConfig, Notification } from './types';
+import type { Channel, Agent, Message, ServerMessage, TodoItem, NorthStar, Pin, PatrolConfig, Notification, DirectMessage, DmConversation } from './types';
 
 const WS_URL = `ws://${window.location.hostname}:3100`;
+
+type ActiveView = { type: 'channel'; id: string } | { type: 'dm'; partnerId: string };
 
 export default function App() {
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -27,6 +30,10 @@ export default function App() {
   const [patrolConfig, setPatrolConfigState] = useState<PatrolConfig | null>(null);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [notificationBadges, setNotificationBadges] = useState<Record<string, number>>({});
+  const [activeView, setActiveView] = useState<ActiveView | null>(null);
+  const [dmMessages, setDmMessages] = useState<Record<string, DirectMessage[]>>({});
+  const [dmConversations, setDmConversations] = useState<DmConversation[]>([]);
+  const [dmUnread, setDmUnread] = useState<Record<string, number>>({});
 
   const handleMessage = useCallback((msg: ServerMessage) => {
     switch (msg.type) {
@@ -140,6 +147,21 @@ export default function App() {
       case 'agent_removed':
         setAgents((prev) => prev.filter((a) => a.id !== msg.id));
         break;
+      case 'dm_message':
+        setDmMessages((prev) => {
+          const partnerId = msg.message.fromId === 'user' ? msg.message.toId : msg.message.fromId;
+          return { ...prev, [partnerId]: [...(prev[partnerId] || []), msg.message] };
+        });
+        break;
+      case 'dm_list':
+        setDmMessages((prev) => ({ ...prev, [msg.withId]: msg.messages }));
+        break;
+      case 'dm_conversations':
+        setDmConversations(msg.conversations);
+        break;
+      case 'dm_unread':
+        setDmUnread(msg.counts);
+        break;
       case 'error':
         console.error('[workshop]', msg.message);
         break;
@@ -151,6 +173,22 @@ export default function App() {
   const handleSendMessage = (content: string) => {
     if (!activeChannelId) return;
     send({ type: 'send_message', channelId: activeChannelId, content });
+  };
+
+  const handleSendDm = (toId: string, content: string) => {
+    send({ type: 'send_dm', toId, content });
+  };
+
+  const handleListDms = (withId: string) => {
+    send({ type: 'list_dms', withId });
+  };
+
+  const handleDmMarkRead = (withId: string) => {
+    send({ type: 'dm_mark_read', withId });
+  };
+
+  const handleListDmConversations = () => {
+    send({ type: 'dm_conversations' });
   };
 
   const handleCreateChannel = (name: string, agentConfigs: { id: string; requireMention: boolean }[]) => {
@@ -215,6 +253,31 @@ export default function App() {
     }
   }, [activeChannelId, connected, send]);
 
+  // Request DM conversations on connect
+  useEffect(() => {
+    if (connected) {
+      handleListDmConversations();
+    }
+  }, [connected]);
+
+  // Load DM messages when switching to a DM view
+  useEffect(() => {
+    if (activeView?.type === 'dm' && connected) {
+      handleListDms(activeView.partnerId);
+      handleDmMarkRead(activeView.partnerId);
+    }
+  }, [activeView, connected]);
+
+  const selectChannel = (channelId: string) => {
+    setActiveChannelId(channelId);
+    setActiveView({ type: 'channel', id: channelId });
+  };
+
+  const selectDm = (partnerId: string) => {
+    setActiveChannelId(null);
+    setActiveView({ type: 'dm', partnerId });
+  };
+
   const handleEditChannel = () => {
     if (!activeChannelId) return;
     setEditingChannel(true);
@@ -236,28 +299,41 @@ export default function App() {
         activeChannelId={activeChannelId}
         notificationBadges={notificationBadges}
         patrolControlChannelId={patrolConfig?.controlChannelId ?? null}
-        onSelectChannel={setActiveChannelId}
+        onSelectChannel={selectChannel}
         onCreateChannel={handleCreateChannel}
-        onOpenSettings={(channelId) => { setActiveChannelId(channelId); setShowChannelSettings(true); }}
+        onOpenSettings={(channelId) => { selectChannel(channelId); setShowChannelSettings(true); }}
         onOpenCronDashboard={() => setShowCronDashboard(true)}
+        dmUnread={dmUnread}
+        activeDmPartnerId={activeView?.type === 'dm' ? activeView.partnerId : null}
+        onSelectDm={selectDm}
       />
-      <ChatView
-        channel={activeChannel ?? null}
-        messages={activeChannelId ? (messages[activeChannelId] || []) : []}
-        channelAgents={channelAgents}
-        typingNames={typingNames}
-        pins={activeChannelId ? (pins[activeChannelId] || []) : []}
-        notifications={notifications.filter(n => n.targetChannelId === activeChannelId)}
-        isPatrolChannel={patrolConfig?.controlChannelId === activeChannelId}
-        onSendMessage={handleSendMessage}
-        onEditChannel={activeChannel ? handleEditChannel : undefined}
-        onOpenSettings={activeChannel ? () => setShowChannelSettings(true) : undefined}
-        onToggleTodo={() => setShowTodoPanel((v) => !v)}
-        onPatrolTrigger={handlePatrolTrigger}
-        onPinCreate={(channelId, content, label) => send({ type: 'pin_create', channelId, content, label })}
-        onPinMessage={(channelId, messageId) => send({ type: 'pin_message', channelId, messageId })}
-        onPinDelete={(pinId) => send({ type: 'pin_delete', pinId })}
-      />
+      {activeView?.type === 'dm' ? (
+        <DmView
+          partnerId={activeView.partnerId}
+          partnerAgent={agents.find(a => a.id === activeView.partnerId) ?? null}
+          messages={dmMessages[activeView.partnerId] || []}
+          onSendMessage={(content) => handleSendDm(activeView.partnerId, content)}
+          onMarkRead={() => handleDmMarkRead(activeView.partnerId)}
+        />
+      ) : (
+        <ChatView
+          channel={activeChannel ?? null}
+          messages={activeChannelId ? (messages[activeChannelId] || []) : []}
+          channelAgents={channelAgents}
+          typingNames={typingNames}
+          pins={activeChannelId ? (pins[activeChannelId] || []) : []}
+          notifications={notifications.filter(n => n.targetChannelId === activeChannelId)}
+          isPatrolChannel={patrolConfig?.controlChannelId === activeChannelId}
+          onSendMessage={handleSendMessage}
+          onEditChannel={activeChannel ? handleEditChannel : undefined}
+          onOpenSettings={activeChannel ? () => setShowChannelSettings(true) : undefined}
+          onToggleTodo={() => setShowTodoPanel((v) => !v)}
+          onPatrolTrigger={handlePatrolTrigger}
+          onPinCreate={(channelId, content, label) => send({ type: 'pin_create', channelId, content, label })}
+          onPinMessage={(channelId, messageId) => send({ type: 'pin_message', channelId, messageId })}
+          onPinDelete={(pinId) => send({ type: 'pin_delete', pinId })}
+        />
+      )}
       {showTodoPanel && (
         <TodoPanel
           items={todoItems}

--- a/web/src/components/DmView.test.tsx
+++ b/web/src/components/DmView.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DmView } from './DmView';
+import type { Agent, DirectMessage } from '../types';
+
+const mockAgent: Agent = {
+  id: 'agent-1',
+  name: 'Alice',
+  status: 'online',
+};
+
+const mockMessages: DirectMessage[] = [
+  { id: 'dm-1', fromId: 'user', toId: 'agent-1', content: 'Hello Alice!', timestamp: '2024-01-01T00:00:00Z', read: true },
+  { id: 'dm-2', fromId: 'agent-1', toId: 'user', content: 'Hi there!', timestamp: '2024-01-01T00:01:00Z', read: true },
+  { id: 'dm-3', fromId: 'user', toId: 'agent-1', content: 'How are you?', timestamp: '2024-01-01T00:02:00Z', read: true },
+];
+
+describe('DmView', () => {
+  it('renders partner name in header', () => {
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={[]}
+        onSendMessage={vi.fn()}
+        onMarkRead={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Alice')).toBeTruthy();
+  });
+
+  it('renders messages with correct sender names', () => {
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={mockMessages}
+        onSendMessage={vi.fn()}
+        onMarkRead={vi.fn()}
+      />
+    );
+    // "You" should appear for user messages, "Alice" for agent messages
+    const yous = screen.getAllByText('You');
+    expect(yous.length).toBe(2);
+    // Alice appears in header + in messages
+    const alices = screen.getAllByText('Alice');
+    expect(alices.length).toBeGreaterThanOrEqual(2); // header + message(s)
+  });
+
+  it('renders message content', () => {
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={mockMessages}
+        onSendMessage={vi.fn()}
+        onMarkRead={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Hello Alice!')).toBeTruthy();
+    expect(screen.getByText('Hi there!')).toBeTruthy();
+    expect(screen.getByText('How are you?')).toBeTruthy();
+  });
+
+  it('shows empty state when no messages', () => {
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={[]}
+        onSendMessage={vi.fn()}
+        onMarkRead={vi.fn()}
+      />
+    );
+    expect(screen.getByText('No messages yet. Start a conversation!')).toBeTruthy();
+  });
+
+  it('calls onSendMessage when form is submitted', () => {
+    const onSendMessage = vi.fn();
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={[]}
+        onSendMessage={onSendMessage}
+        onMarkRead={vi.fn()}
+      />
+    );
+    const input = screen.getByPlaceholderText('Message Alice');
+    fireEvent.change(input, { target: { value: 'Test message' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(onSendMessage).toHaveBeenCalledWith('Test message');
+  });
+
+  it('does not submit empty messages', () => {
+    const onSendMessage = vi.fn();
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={[]}
+        onSendMessage={onSendMessage}
+        onMarkRead={vi.fn()}
+      />
+    );
+    const input = screen.getByPlaceholderText('Message Alice');
+    fireEvent.submit(input.closest('form')!);
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('calls onMarkRead on mount', () => {
+    const onMarkRead = vi.fn();
+    render(
+      <DmView
+        partnerId="agent-1"
+        partnerAgent={mockAgent}
+        messages={[]}
+        onSendMessage={vi.fn()}
+        onMarkRead={onMarkRead}
+      />
+    );
+    expect(onMarkRead).toHaveBeenCalled();
+  });
+
+  it('uses partnerId as name when no agent provided', () => {
+    render(
+      <DmView
+        partnerId="unknown-agent"
+        partnerAgent={null}
+        messages={[]}
+        onSendMessage={vi.fn()}
+        onMarkRead={vi.fn()}
+      />
+    );
+    expect(screen.getByText('unknown-agent')).toBeTruthy();
+  });
+});

--- a/web/src/components/DmView.tsx
+++ b/web/src/components/DmView.tsx
@@ -1,0 +1,126 @@
+import { useState, useRef, useEffect } from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import { MessageContent } from '@/components/MessageContent';
+import type { Agent, DirectMessage } from '../types';
+
+interface DmViewProps {
+  partnerId: string;
+  partnerAgent: Agent | null;
+  messages: DirectMessage[];
+  onSendMessage: (content: string) => void;
+  onMarkRead: () => void;
+}
+
+export function DmView({ partnerId, partnerAgent, messages, onSendMessage, onMarkRead }: DmViewProps) {
+  const [input, setInput] = useState('');
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  // Mark as read on focus
+  useEffect(() => {
+    onMarkRead();
+  }, [partnerId]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    onSendMessage(trimmed);
+    setInput('');
+  };
+
+  const formatTime = (ts: string) => {
+    try {
+      return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  };
+
+  const partnerName = partnerAgent?.name ?? partnerId;
+  const avatarUrl = partnerAgent?.avatar?.startsWith('http') ? partnerAgent.avatar : null;
+
+  return (
+    <div className="flex-1 flex flex-col bg-muted">
+      <div className="p-3 px-4 border-b border-border">
+        <div className="flex items-center gap-2">
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt={partnerName}
+              className="w-6 h-6 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold bg-discord-accent text-white">
+              {partnerName.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <span className="font-semibold">{partnerName}</span>
+          {partnerAgent && (
+            <span className={cn(
+              'w-2 h-2 rounded-full',
+              partnerAgent.status === 'online' ? 'bg-green-500' : partnerAgent.status === 'connecting' ? 'bg-yellow-500' : 'bg-muted-foreground/40'
+            )} />
+          )}
+        </div>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-4" ref={listRef}>
+          {messages.length === 0 && (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+              No messages yet. Start a conversation!
+            </div>
+          )}
+          {messages.map((msg) => {
+            const isUser = msg.fromId === 'user';
+            const senderName = isUser ? 'You' : partnerName;
+            const senderAvatarUrl = isUser ? null : avatarUrl;
+            return (
+              <div key={msg.id} className="flex gap-3 py-1 mb-2">
+                {senderAvatarUrl ? (
+                  <img
+                    src={senderAvatarUrl}
+                    alt={senderName}
+                    className="w-10 h-10 rounded-full object-cover shrink-0"
+                  />
+                ) : (
+                  <div
+                    className={cn(
+                      'w-10 h-10 rounded-full flex items-center justify-center text-base font-semibold shrink-0 text-white',
+                      isUser ? 'bg-discord-online' : 'bg-discord-accent'
+                    )}
+                  >
+                    {senderName.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2 mb-0.5">
+                    <span className="font-semibold text-sm">{senderName}</span>
+                    <span className="text-[11px] text-muted-foreground">{formatTime(msg.timestamp)}</span>
+                  </div>
+                  <MessageContent content={msg.content} agents={[]} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+      <form className="p-4" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={`Message ${partnerName}`}
+          className="w-full py-3 px-4 rounded-lg bg-card text-foreground text-sm outline-none border-none placeholder:text-muted-foreground/60"
+        />
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -14,9 +14,12 @@ interface SidebarProps {
   onCreateChannel: (name: string, agents: { id: string; requireMention: boolean }[]) => void;
   onOpenSettings: (channelId: string) => void;
   onOpenCronDashboard: () => void;
+  dmUnread: Record<string, number>;
+  activeDmPartnerId: string | null;
+  onSelectDm: (partnerId: string) => void;
 }
 
-export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard }: SidebarProps) {
+export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard, dmUnread, activeDmPartnerId, onSelectDm }: SidebarProps) {
   const [showDialog, setShowDialog] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
 
@@ -109,6 +112,36 @@ export function Sidebar({ channels, agents, activeChannelId, notificationBadges,
                   >
                     &#9881;
                   </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Direct Messages section */}
+          {agents.length > 0 && (
+            <div className="mt-4">
+              <div className="flex items-center justify-between px-3 pb-2 pt-1">
+                <span className="uppercase tracking-wide text-xs font-semibold text-muted-foreground">Direct Messages</span>
+              </div>
+              {agents.map((agent) => (
+                <div
+                  key={agent.id}
+                  className={cn(
+                    "px-3 py-2 rounded cursor-pointer text-muted-foreground hover:bg-accent hover:text-foreground text-sm flex items-center gap-2",
+                    agent.id === activeDmPartnerId && 'bg-accent text-foreground'
+                  )}
+                  onClick={() => onSelectDm(agent.id)}
+                >
+                  <span className={cn(
+                    'w-2 h-2 rounded-full shrink-0',
+                    agent.status === 'online' ? 'bg-green-500' : agent.status === 'connecting' ? 'bg-yellow-500' : 'bg-muted-foreground/40'
+                  )} />
+                  <span className="flex-1 truncate">{agent.name}</span>
+                  {(dmUnread[agent.id] ?? 0) > 0 && (
+                    <span className="shrink-0 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold leading-none px-1">
+                      {dmUnread[agent.id]}
+                    </span>
+                  )}
                 </div>
               ))}
             </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -74,6 +74,23 @@ export interface Message {
   isUrgent: boolean;
 }
 
+export interface DirectMessage {
+  id: string;
+  fromId: string;
+  toId: string;
+  content: string;
+  timestamp: string;
+  read: boolean;
+}
+
+export interface DmConversation {
+  partnerId: string;
+  partnerName: string;
+  lastMessage: string;
+  lastTimestamp: string;
+  unreadCount: number;
+}
+
 // Messages from server
 export type ServerMessage =
   | { type: 'message'; channelId: string; message: Message }
@@ -102,6 +119,10 @@ export type ServerMessage =
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }
+  | { type: 'dm_message'; message: DirectMessage }
+  | { type: 'dm_list'; withId: string; messages: DirectMessage[] }
+  | { type: 'dm_conversations'; conversations: DmConversation[] }
+  | { type: 'dm_unread'; counts: Record<string, number> }
   | { type: 'error'; message: string };
 
 // Messages from client → server
@@ -133,7 +154,11 @@ export type ClientMessage =
   | { type: 'rename_channel'; channelId: string; name: string }
   | { type: 'register_agent'; agent: { id: string; name: string; avatar?: string } }
   | { type: 'update_agent'; id: string; updates: Partial<{ name: string; avatar: string }> }
-  | { type: 'remove_agent'; id: string };
+  | { type: 'remove_agent'; id: string }
+  | { type: 'send_dm'; toId: string; content: string }
+  | { type: 'list_dms'; withId: string; limit?: number; before?: string }
+  | { type: 'dm_mark_read'; withId: string }
+  | { type: 'dm_conversations' };
 
 export interface CreateChannelDialogProps {
   agents: Agent[];


### PR DESCRIPTION
## Summary

Add 1:1 direct messaging between agents and users — the first step toward agent-to-agent coordination outside of channels.

## Changes

### Server
- `direct_messages` table with participant index for efficient lookups
- 4 new WebSocket message types: `send_dm`, `list_dms`, `dm_mark_read`, `dm_conversations`
- Unread DM counts sent automatically on client connect
- Conversations endpoint returns all DM partners with last message and unread count

### Frontend
- **Sidebar**: New 'Direct Messages' section showing all agents with status dots and unread badges
- **DmView**: New component with message history, input box, partner avatar/name header, auto-scroll, mark-as-read on focus
- **App**: ActiveView routing between channels and DMs

### Tests
- 19 new tests (11 server + 8 web)
- All 102 tests pass (was 83)
- TypeScript compiles clean

## Design Decisions
- DMs are store-and-display (no gateway AI routing) — keeps it simple, agents interact through the UI
- Separate from channels (not a special channel type) — cleaner data model
- Pagination support via `before` cursor in `list_dms`