### PR TITLE
feat: per-channel native TODO board with kanban view

### DIFF
--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,0 +1,62 @@
+# Workshop — Product Definition
+
+> 2026-04-13 Luna + Kagura 讨论确认
+
+## 一句话
+
+Workshop 是我们的项目管理工具，聊天是交互方式。
+
+## 谁用
+
+Luna（人类）+ Kagura（AI agent）+ 未来可能的协作 agent。不考虑外部用户。
+
+## 核心洞察
+
+我们在 Discord 上手工搭了一套 agent 自治体系（channel 自治、cron、TODO pin、总控室）。能用，但 Discord 不是为这个设计的 — 项目管理是硬塞进去的。
+
+Workshop 反过来：**项目管理是骨架，聊天长在上面。**
+
+## 三件事
+
+### 1. 总控室
+打开就看到：
+- 北极星（我们在干嘛）
+- 所有项目当前状态
+- 哪些任务卡住了、哪些在推进
+- 不是一个聊天室，是一个 Dashboard
+
+### 2. 项目空间
+每个项目一个 room：
+- 原生 TODO list（不是 pin，不受字符限制）
+- 聊天记录（讨论、决策、上下文）
+- 活动摘要（agent 干了什么，不刷屏）
+- 点进去就是这个项目的一切
+
+### 3. Agent 自治
+- 任务自动流转（Backlog → In Progress → Done）
+- Kagura 在各个项目空间里自主干活
+- Luna 不需要盯，想介入随时走进来聊
+- 聊天是为了人和 agent 交互把项目推进起来
+
+## 跟 Discord 的区别
+
+| | Discord | Workshop |
+|---|---|---|
+| 本质 | 聊天工具，项目管理硬塞 | 项目管理工具，聊天长在上面 |
+| TODO | Pin（2000 字符限制） | 原生 task list，状态流转 |
+| 全局视图 | 没有 | Dashboard 总控室 |
+| 活动记录 | Thread 堆积，cron 刷屏 | 摘要模式 |
+| 跨项目上下文 | 丢失 | 共享 |
+
+## 不做什么
+
+- 不做平台 / 不做给别人用的 SaaS
+- 不做 Agent API / 不做 framework 抽象层（至少现在不做）
+- 不做 public spectator mode
+- 不替代 Discord（社交、社区讨论继续在 Discord）
+
+## 开发原则
+
+- Claude Code 写所有代码，用 ralph-loop 拆任务
+- 自己做自己测（dogfooding）— Kagura 是第一用户
+- 从 Discord 痛点出发，每个功能都能立刻感受到"比 Discord 好"

--- a/docs/v0.4-agent-api.md
+++ b/docs/v0.4-agent-api.md
@@ -1,0 +1,60 @@
+# Workshop v0.4 — Agent API + 平台化
+
+## 背景
+
+2026-04-13 Luna 和 Kagura 讨论后确定的方向。
+
+### 核心定位
+
+Workshop 是 **surface layer** — 和 Discord、Slack 一个层级的协作界面。不依赖 OpenClaw/Hermes 任何特定 framework 的生态。
+
+```
+Surface:    Discord | Slack | Workshop
+             ↕        ↕       ↕
+Framework:  OpenClaw | Hermes | Isotopes | 自定义
+             ↕        ↕       ↕
+Provider:   Anthropic | OpenAI | ...
+```
+
+任何 agent framework 通过 Workshop Agent API 接入，就像 bot 通过 Discord Bot API 接入。
+
+### 为什么
+
+Discord 管理多项目 + agent 协作的痛点（2026-04-13 实际踩坑）：
+
+1. **Pin 2000 字符限制** — TODO 变长后 pin 更新静默失败，我们是查了 handler 源码才发现
+2. **无任务状态流转** — Channel 只有"在"和"不在"，没有 Backlog → In Progress → Done
+3. **Thread 堆积** — cron 每次跑完开 thread，过几天就找不到了
+4. **Cron 输出刷屏** — announce 模式把中间过程全发到 channel
+5. **跨 channel 上下文丢失** — 在 #kagura-dm 讨论的产品方向，#workshop channel 的 cron 完全不知道
+6. **Project Board 不适合混合任务** — 试了 GitHub Project Board 发现不适合管"习惯"和"方向"类任务，只适合有明确起止的开发任务
+
+### Workshop 要解决的
+
+保留 Discord 好的（实时沟通、@mention、低门槛），修掉不好的：
+- 原生长 TODO 看板（不受字符限制）
+- 内建任务状态流转
+- Agent 活动摘要（不刷屏）
+- 跨 channel 上下文共享
+- Dashboard 全局视图
+
+## v0.4 目标
+
+1. **Agent API 设计** — 定义 Workshop Agent Protocol（注册、消息收发、状态上报），参考 Discord Bot API
+2. **重构** — Workshop server 不直接调 LLM，改为通过 Agent API 对接外部 framework
+3. **OpenClaw adapter** — 让 OpenClaw agent 通过 Agent API 接入 Workshop（就像 OpenClaw 的 Discord channel adapter）
+4. **平台能力** — Workshop 是纯 UI + 状态管理 + 平台能力（TODO、cron、patrol 等）
+
+## v0.3 已完成
+
+19 个 PR 全部 merged：
+- Channel metadata system（定位/准则/北极星）
+- Global TODO + per-channel task sections
+- Cron-driven channel autonomy
+- Channel patrol → control room summary
+- Cross-channel notifications
+- Real-time human intervention
+- Kanban view + Cron Dashboard
+- Channel lifecycle（delete/archive/rename）
+- Markdown rendering + agent avatars
+- Agent-to-agent direct messaging

--- a/server/src/__tests__/router.test.ts
+++ b/server/src/__tests__/router.test.ts
@@ -744,4 +744,71 @@ describe('router.ts - Core business logic', () => {
       expect(gateway.sendChat).not.toHaveBeenCalled();
     });
   });
+
+  // ------- Channel TODO (per-channel) -------
+  describe('Channel TODO (per-channel)', () => {
+    it('channel_todo_list returns only items for that channel', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      // Create items: one assigned to test-channel, one to other-channel, one global
+      (ctx.router as any).handleTodoCreate('backlog', 'task for test', 'test-channel');
+      (ctx.router as any).handleTodoCreate('backlog', 'task for other', 'other-channel');
+      (ctx.router as any).handleTodoCreate('backlog', 'global task');
+
+      ctx.clearSent();
+      (ctx.router as any).handleChannelTodoList(ctx.mockWs, 'test-channel');
+
+      const lists = ctx.sentOfType('channel_todo_list');
+      expect(lists).toHaveLength(1);
+      expect(lists[0].channelId).toBe('test-channel');
+      expect(lists[0].items).toHaveLength(1);
+      expect(lists[0].items[0].content).toBe('task for test');
+    });
+
+    it('channel_todo_create creates item with correct assigned_channel and section', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      (ctx.router as any).handleChannelTodoCreate('test-channel', 'channel task');
+
+      const db = getDb();
+      const items = db.prepare('SELECT * FROM todo_items WHERE assigned_channel = ?').all('test-channel') as any[];
+      expect(items).toHaveLength(1);
+      expect(items[0].content).toBe('channel task');
+      expect(items[0].assigned_channel).toBe('test-channel');
+      expect(items[0].section).toBe('Test Channel'); // defaults to channel name
+      expect(items[0].status).toBe('pending');
+    });
+
+    it('channel_todo_create broadcasts todo_created and channel_todo_list', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      ctx.clearSent();
+      (ctx.router as any).handleChannelTodoCreate('test-channel', 'new channel task');
+
+      const created = ctx.sentOfType('todo_created');
+      expect(created).toHaveLength(1);
+      expect(created[0].item.content).toBe('new channel task');
+      expect(created[0].item.assignedChannel).toBe('test-channel');
+
+      const lists = ctx.sentOfType('channel_todo_list');
+      expect(lists).toHaveLength(1);
+      expect(lists[0].channelId).toBe('test-channel');
+      expect(lists[0].items).toHaveLength(1);
+    });
+
+    it('global todo_list still returns all items', () => {
+      (ctx.router as any).clients.add(ctx.mockWs);
+
+      // Create channel-specific and global items
+      (ctx.router as any).handleChannelTodoCreate('test-channel', 'channel task');
+      (ctx.router as any).handleTodoCreate('backlog', 'global task');
+
+      ctx.clearSent();
+      (ctx.router as any).handleTodoList(ctx.mockWs);
+
+      const lists = ctx.sentOfType('todo_list');
+      expect(lists).toHaveLength(1);
+      expect(lists[0].items).toHaveLength(2);
+    });
+  });
 });

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -30,6 +30,7 @@ export class Router {
     this.sendAllNotificationBadges(ws);
     this.handlePatrolConfigGet(ws);
     this.sendDmUnread(ws);
+    this.sendAllChannelTodos(ws);
 
     ws.on('message', (raw) => {
       try {
@@ -211,6 +212,12 @@ export class Router {
         break;
       case 'dm_conversations':
         this.handleDmConversations(ws);
+        break;
+      case 'channel_todo_list':
+        this.handleChannelTodoList(ws, msg.channelId);
+        break;
+      case 'channel_todo_create':
+        this.handleChannelTodoCreate(msg.channelId, msg.content, msg.status);
         break;
       default:
         this.sendTo(ws, { type: 'error', message: 'Unknown message type' });
@@ -640,6 +647,39 @@ export class Router {
     }
   }
 
+  private handleChannelTodoList(ws: WebSocket, channelId: string): void {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM todo_items WHERE assigned_channel = ? ORDER BY created_at ASC').all(channelId) as any[];
+    const items: TodoItem[] = rows.map(this.mapTodoRow);
+    this.sendTo(ws, { type: 'channel_todo_list', channelId, items });
+  }
+
+  private handleChannelTodoCreate(channelId: string, content: string, status?: string): void {
+    const db = getDb();
+    const id = uuid();
+    const now = new Date().toISOString();
+
+    // Default section to channel name
+    const channelRow = db.prepare('SELECT name FROM channels WHERE id = ?').get(channelId) as any;
+    const section = channelRow?.name ?? channelId;
+    const todoStatus = status ?? 'pending';
+
+    db.prepare(
+      'INSERT INTO todo_items (id, section, content, status, assigned_channel, assigned_agent, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, section, content, todoStatus, channelId, null, now, now);
+
+    const item: TodoItem = { id, section, content, status: todoStatus as any, assignedChannel: channelId, assignedAgent: null, createdAt: now, updatedAt: now };
+    this.broadcast({ type: 'todo_created', item });
+    this.broadcast({ type: 'channel_todo_list', channelId, items: this.getChannelTodoItems(channelId) });
+    this.syncTodoSectionPins(section);
+  }
+
+  private getChannelTodoItems(channelId: string): TodoItem[] {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM todo_items WHERE assigned_channel = ? ORDER BY created_at ASC').all(channelId) as any[];
+    return rows.map(this.mapTodoRow);
+  }
+
   private mapTodoRow(r: any): TodoItem {
     return {
       id: r.id,
@@ -864,6 +904,19 @@ export class Router {
 
     const executions = this.cronManager.getHistory(channelId);
     this.sendTo(ws, { type: 'cron_history', channelId, executions });
+  }
+
+  private sendAllChannelTodos(ws: WebSocket): void {
+    const db = getDb();
+    const channels = db.prepare('SELECT id FROM channels').all() as { id: string }[];
+
+    for (const { id: channelId } of channels) {
+      const rows = db.prepare('SELECT * FROM todo_items WHERE assigned_channel = ? ORDER BY created_at ASC').all(channelId) as any[];
+      if (rows.length > 0) {
+        const items: TodoItem[] = rows.map(this.mapTodoRow);
+        this.sendTo(ws, { type: 'channel_todo_list', channelId, items });
+      }
+    }
   }
 
   private sendAllChannelHistory(ws: WebSocket): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -103,7 +103,9 @@ export type ClientMessage =
   | { type: 'send_dm'; toId: string; content: string }
   | { type: 'list_dms'; withId: string; limit?: number; before?: string }
   | { type: 'dm_mark_read'; withId: string }
-  | { type: 'dm_conversations' };
+  | { type: 'dm_conversations' }
+  | { type: 'channel_todo_list'; channelId: string }
+  | { type: 'channel_todo_create'; channelId: string; content: string; status?: TodoStatus };
 
 // WebSocket protocol: server → client
 export type ServerMessage =
@@ -137,6 +139,7 @@ export type ServerMessage =
   | { type: 'dm_list'; withId: string; messages: DirectMessage[] }
   | { type: 'dm_conversations'; conversations: DmConversation[] }
   | { type: 'dm_unread'; counts: Record<string, number> }
+  | { type: 'channel_todo_list'; channelId: string; items: TodoItem[] }
   | { type: 'error'; message: string };
 
 export interface NorthStar {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ export default function App() {
   const [dmMessages, setDmMessages] = useState<Record<string, DirectMessage[]>>({});
   const [dmConversations, setDmConversations] = useState<DmConversation[]>([]);
   const [dmUnread, setDmUnread] = useState<Record<string, number>>({});
+  const [channelTodos, setChannelTodos] = useState<Record<string, TodoItem[]>>({});
 
   const handleMessage = useCallback((msg: ServerMessage) => {
     switch (msg.type) {
@@ -161,6 +162,9 @@ export default function App() {
         break;
       case 'dm_unread':
         setDmUnread(msg.counts);
+        break;
+      case 'channel_todo_list':
+        setChannelTodos((prev) => ({ ...prev, [msg.channelId]: msg.items }));
         break;
       case 'error':
         console.error('[workshop]', msg.message);
@@ -332,6 +336,11 @@ export default function App() {
           onPinCreate={(channelId, content, label) => send({ type: 'pin_create', channelId, content, label })}
           onPinMessage={(channelId, messageId) => send({ type: 'pin_message', channelId, messageId })}
           onPinDelete={(pinId) => send({ type: 'pin_delete', pinId })}
+          channelTodoItems={activeChannelId ? (channelTodos[activeChannelId] || []) : []}
+          onChannelTodoCreate={(channelId, content, status) => send({ type: 'channel_todo_create', channelId, content, status })}
+          onChannelTodoUpdate={(id, updates) => send({ type: 'todo_update', id, updates })}
+          onChannelTodoDelete={(id) => send({ type: 'todo_delete', id })}
+          onChannelTodoRefresh={(channelId) => send({ type: 'channel_todo_list', channelId })}
         />
       )}
       {showTodoPanel && (

--- a/web/src/components/ChannelTodoPanel.tsx
+++ b/web/src/components/ChannelTodoPanel.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { TodoItem, TodoStatus } from '../types';
+
+interface ChannelTodoPanelProps {
+  channelId: string;
+  items: TodoItem[];
+  onClose: () => void;
+  onCreate: (channelId: string, content: string) => void;
+  onUpdate: (id: string, updates: Partial<Pick<TodoItem, 'content' | 'status' | 'section' | 'assignedChannel' | 'assignedAgent'>>) => void;
+  onDelete: (id: string) => void;
+}
+
+const STATUS_CYCLE: TodoStatus[] = ['pending', 'in_progress', 'review', 'done'];
+
+const STATUS_CONFIG: Record<TodoStatus, { label: string; color: string; bg: string; headerBg: string }> = {
+  pending: { label: 'Pending', color: 'text-muted-foreground', bg: 'bg-muted-foreground/20', headerBg: 'bg-muted-foreground/10' },
+  in_progress: { label: 'In Progress', color: 'text-blue-400', bg: 'bg-blue-400/20', headerBg: 'bg-blue-400/10' },
+  review: { label: 'Review', color: 'text-yellow-400', bg: 'bg-yellow-400/20', headerBg: 'bg-yellow-400/10' },
+  done: { label: 'Done', color: 'text-green-400', bg: 'bg-green-400/20', headerBg: 'bg-green-400/10' },
+};
+
+export function ChannelTodoPanel({ channelId, items, onClose, onCreate, onUpdate, onDelete }: ChannelTodoPanelProps) {
+  const [newContent, setNewContent] = useState('');
+
+  const columns = new Map<TodoStatus, TodoItem[]>();
+  for (const status of STATUS_CYCLE) {
+    columns.set(status, []);
+  }
+  for (const item of items) {
+    columns.get(item.status)!.push(item);
+  }
+
+  const handleAdd = () => {
+    const content = newContent.trim();
+    if (!content) return;
+    onCreate(channelId, content);
+    setNewContent('');
+  };
+
+  const cycleStatus = (item: TodoItem) => {
+    const idx = STATUS_CYCLE.indexOf(item.status);
+    const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
+    onUpdate(item.id, { status: next });
+  };
+
+  return (
+    <div className="border-b border-border bg-card/50">
+      <div className="p-2 px-4 flex items-center justify-between">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Channel Tasks ({items.length})</span>
+        <button className="text-muted-foreground hover:text-foreground cursor-pointer text-sm leading-none" onClick={onClose}>
+          &times;
+        </button>
+      </div>
+      <div className="flex gap-1.5 px-4 pb-2 overflow-x-auto min-h-0">
+        {STATUS_CYCLE.map((status) => {
+          const cfg = STATUS_CONFIG[status];
+          const colItems = columns.get(status) || [];
+          return (
+            <div key={status} className="flex-1 min-w-[120px] flex flex-col min-h-0">
+              <div className={cn('rounded-t px-2 py-1 flex items-center gap-1.5', cfg.headerBg)}>
+                <span className={cn('text-[10px] font-semibold', cfg.color)}>{cfg.label}</span>
+                <span className="text-[9px] text-muted-foreground">{colItems.length}</span>
+              </div>
+              <ScrollArea className="flex-1 border border-t-0 border-border rounded-b max-h-[150px]">
+                <div className="p-1 space-y-1">
+                  {colItems.length === 0 && (
+                    <div className="text-muted-foreground text-[9px] text-center py-2">Empty</div>
+                  )}
+                  {colItems.map((item) => (
+                    <div
+                      key={item.id}
+                      className="group bg-muted/50 rounded p-1.5 text-[11px] hover:bg-muted"
+                    >
+                      <div className="flex items-start justify-between gap-1">
+                        <span className={cn('flex-1 break-words', item.status === 'done' && 'line-through text-muted-foreground')}>
+                          {item.content}
+                        </span>
+                        <button
+                          className="shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive cursor-pointer text-[9px]"
+                          onClick={() => onDelete(item.id)}
+                          title="Delete"
+                        >
+                          &times;
+                        </button>
+                      </div>
+                      <div className="mt-1 flex items-center">
+                        <button
+                          className={cn('px-1 py-0.5 rounded text-[8px] font-medium cursor-pointer', cfg.bg, cfg.color)}
+                          onClick={() => cycleStatus(item)}
+                          title="Click to advance status"
+                        >
+                          {cfg.label}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            </div>
+          );
+        })}
+      </div>
+      <div className="px-4 pb-2">
+        <div className="flex gap-1.5">
+          <Input
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="New channel task..."
+            className="bg-muted text-xs h-7"
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); }}
+          />
+          <Button size="sm" className="h-7 px-2 text-xs" onClick={handleAdd}>Add</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -3,7 +3,8 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { MessageContent } from '@/components/MessageContent';
-import type { Agent, Channel, Message, Pin, Notification } from '../types';
+import type { Agent, Channel, Message, Pin, Notification, TodoItem, TodoStatus } from '../types';
+import { ChannelTodoPanel } from '@/components/ChannelTodoPanel';
 
 const TYPE_BADGE: Record<string, { label: string; className: string }> = {
   project: { label: 'Project', className: 'bg-discord-accent/20 text-discord-accent' },
@@ -27,9 +28,14 @@ interface ChatViewProps {
   onPinCreate?: (channelId: string, content: string, label?: string) => void;
   onPinMessage?: (channelId: string, messageId: string) => void;
   onPinDelete?: (pinId: string) => void;
+  channelTodoItems?: TodoItem[];
+  onChannelTodoCreate?: (channelId: string, content: string, status?: TodoStatus) => void;
+  onChannelTodoUpdate?: (id: string, updates: Partial<Pick<TodoItem, 'content' | 'status' | 'section' | 'assignedChannel' | 'assignedAgent'>>) => void;
+  onChannelTodoDelete?: (id: string) => void;
+  onChannelTodoRefresh?: (channelId: string) => void;
 }
 
-export function ChatView({ channel, messages, channelAgents, typingNames, pins, notifications, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onToggleTodo, onPatrolTrigger, onPinCreate, onPinMessage, onPinDelete }: ChatViewProps) {
+export function ChatView({ channel, messages, channelAgents, typingNames, pins, notifications, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onToggleTodo, onPatrolTrigger, onPinCreate, onPinMessage, onPinDelete, channelTodoItems, onChannelTodoCreate, onChannelTodoUpdate, onChannelTodoDelete, onChannelTodoRefresh }: ChatViewProps) {
   const [input, setInput] = useState('');
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
@@ -38,6 +44,7 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
   const [showPinForm, setShowPinForm] = useState(false);
   const [pinFormContent, setPinFormContent] = useState('');
   const [pinFormLabel, setPinFormLabel] = useState('');
+  const [showChannelTodos, setShowChannelTodos] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -178,6 +185,18 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
                 &#9745;
               </button>
             )}
+            {onChannelTodoCreate && (
+              <button
+                className={cn(
+                  'cursor-pointer text-sm px-1.5',
+                  showChannelTodos ? 'text-blue-400 hover:text-blue-300' : 'text-muted-foreground hover:text-foreground'
+                )}
+                onClick={() => setShowChannelTodos((v) => !v)}
+                title="Toggle channel tasks"
+              >
+                &#9744;
+              </button>
+            )}
             {onOpenSettings && (
               <button
                 className="cursor-pointer text-muted-foreground hover:text-foreground"
@@ -298,6 +317,16 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
             );
           })()}
         </div>
+      )}
+      {showChannelTodos && channel && onChannelTodoCreate && onChannelTodoUpdate && onChannelTodoDelete && (
+        <ChannelTodoPanel
+          channelId={channel.id}
+          items={channelTodoItems || []}
+          onClose={() => setShowChannelTodos(false)}
+          onCreate={onChannelTodoCreate}
+          onUpdate={onChannelTodoUpdate}
+          onDelete={onChannelTodoDelete}
+        />
       )}
       <ScrollArea className="flex-1">
         <div className="p-4" ref={listRef}>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -123,6 +123,7 @@ export type ServerMessage =
   | { type: 'dm_list'; withId: string; messages: DirectMessage[] }
   | { type: 'dm_conversations'; conversations: DmConversation[] }
   | { type: 'dm_unread'; counts: Record<string, number> }
+  | { type: 'channel_todo_list'; channelId: string; items: TodoItem[] }
   | { type: 'error'; message: string };
 
 // Messages from client → server
@@ -158,7 +159,9 @@ export type ClientMessage =
   | { type: 'send_dm'; toId: string; content: string }
   | { type: 'list_dms'; withId: string; limit?: number; before?: string }
   | { type: 'dm_mark_read'; withId: string }
-  | { type: 'dm_conversations' };
+  | { type: 'dm_conversations' }
+  | { type: 'channel_todo_list'; channelId: string }
+  | { type: 'channel_todo_create'; channelId: string; content: string; status?: TodoStatus };
 
 export interface CreateChannelDialogProps {
   agents: Agent[];


### PR DESCRIPTION
## What
Per-channel native TODO board — first piece of Workshop v0.4 Step 1.

## Changes
- **Server**: New `channel_todo_list` and `channel_todo_create` WS message types. Filter todos by `assigned_channel`, auto-assign on create. Send per-channel todos on client connect.
- **Web**: New `ChannelTodoPanel` component with 4-column kanban (pending/in_progress/review/done). Toggle via ☐ button in channel header.
- **Types**: Matching client/server message types added to both server and web.
- **Tests**: 4 new server tests. All pass: server 70/70, web 36/36.
- **Docs**: Added PRODUCT.md and v0.4-agent-api.md planning docs.

## Why
Discord's 2000-char pin limit makes TODO management painful. Native per-channel tasks stored in DB have no limit and support proper status flow.

Part of: Workshop v0.4 Step 1 (原生 TODO 看板)