### PR TITLE
docs: rewrite PRODUCT.md for new direction — independent surface layer

### DIFF
--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,62 +1,106 @@
 # Workshop — Product Definition
 
-> 2026-04-13 Luna + Kagura 讨论确认
+> 2026-04-14 更新，基于 Luna + Kagura 讨论确认的新方向
 
 ## 一句话
 
-Workshop 是我们的项目管理工具，聊天是交互方式。
+Workshop 是人类+AI agent 团队的协作界面 — Discord for AI teams, done right.
 
-## 谁用
+## 核心定位
 
-Luna（人类）+ Kagura（AI agent）+ 未来可能的协作 agent。不考虑外部用户。
+Workshop 是 **surface layer** — 和 Discord、Slack 同一层级的协作平台。
 
-## 核心洞察
+不是 framework，不是 orchestrator，不绑定任何特定 agent 框架。任何 agent framework 通过 Workshop Agent API 接入，就像 bot 通过 Discord Bot API 接入。
 
-我们在 Discord 上手工搭了一套 agent 自治体系（channel 自治、cron、TODO pin、总控室）。能用，但 Discord 不是为这个设计的 — 项目管理是硬塞进去的。
+```
+Surface:    Discord | Slack | Workshop
+              ↕       ↕       ↕
+API:        Bot API   App API  Agent API
+              ↕       ↕       ↕
+Framework:  自定义   自定义   OpenClaw / Hermes / 任何框架
+```
 
-Workshop 反过来：**项目管理是骨架，聊天长在上面。**
+## 以 Project 为核心
 
-## 三件事
+Project 是一切的组织单元（不是 channel）。每个 Project 包含：
 
-### 1. 总控室
-打开就看到：
-- 北极星（我们在干嘛）
-- 所有项目当前状态
-- 哪些任务卡住了、哪些在推进
-- 不是一个聊天室，是一个 Dashboard
+- **TODO 看板** — 原生任务列表，状态流转（Backlog → In Progress → Done），不受字符限制
+- **聊天** — 实时讨论、决策、上下文，人和 agent 自然交互
+- **活动摘要** — agent 干了什么，不刷屏，摘要模式
+- **配置** — Project 级别的 cron、patrol、agent 权限
 
-### 2. 项目空间
-每个项目一个 room：
-- 原生 TODO list（不是 pin，不受字符限制）
-- 聊天记录（讨论、决策、上下文）
-- 活动摘要（agent 干了什么，不刷屏）
-- 点进去就是这个项目的一切
+点进一个 Project，就是这个项目的一切。
 
-### 3. Agent 自治
-- 任务自动流转（Backlog → In Progress → Done）
-- Kagura 在各个项目空间里自主干活
-- Luna 不需要盯，想介入随时走进来聊
-- 聊天是为了人和 agent 交互把项目推进起来
+Dashboard 总控室给你全局视图：所有项目状态、卡住的任务、正在推进的工作。
 
-## 跟 Discord 的区别
+## 解决什么
 
-| | Discord | Workshop |
-|---|---|---|
-| 本质 | 聊天工具，项目管理硬塞 | 项目管理工具，聊天长在上面 |
-| TODO | Pin（2000 字符限制） | 原生 task list，状态流转 |
+Discord 管理多项目 + agent 协作的实际痛点（2026-04-13 踩坑总结）：
+
+| 痛点 | Discord | Workshop |
+|------|---------|----------|
+| TODO 管理 | Pin（2000 字符限制，超了静默失败） | 原生看板，无限制 |
+| 任务状态 | Channel 只有"在"和"不在" | Backlog → In Progress → Done |
+| 活动记录 | Thread 堆积，几天就找不到 | 摘要模式，结构化 |
+| Agent 输出 | Cron announce 刷屏 | 活动摘要，不打扰 |
+| 跨项目上下文 | Channel 之间完全隔离 | 共享上下文 |
 | 全局视图 | 没有 | Dashboard 总控室 |
-| 活动记录 | Thread 堆积，cron 刷屏 | 摘要模式 |
-| 跨项目上下文 | 丢失 | 共享 |
+| Agent 接入 | Bot API，但平台不为 agent 设计 | Agent API，原生支持 |
+
+保留 Discord 好的部分：实时沟通、@mention、低门槛。
+
+## 三层架构
+
+```
+┌─────────────────────────────────────────┐
+│  Workshop (Surface Layer)               │
+│  UI + 状态管理 + 平台能力               │
+│  (TODO, cron, patrol, chat, dashboard)  │
+└────────────────┬────────────────────────┘
+                 │ Agent API (Workshop Agent Protocol)
+                 │ 注册 / 消息收发 / 状态上报
+┌────────────────┴────────────────────────┐
+│  Agent Framework (任意)                 │
+│  OpenClaw / Hermes / LangGraph / 自定义  │
+└─────────────────────────────────────────┘
+```
+
+Workshop 只管 surface：UI、状态、平台能力。Agent 的决策、编排、LLM 调用全在 framework 层。
+
+Agent API 是两层之间的契约。
 
 ## 不做什么
 
-- 不做平台 / 不做给别人用的 SaaS
-- 不做 Agent API / 不做 framework 抽象层（至少现在不做）
-- 不做 public spectator mode
-- 不替代 Discord（社交、社区讨论继续在 Discord）
+- **不做 framework** — 不管 agent 怎么想、怎么决策、怎么调 LLM
+- **不做 orchestrator** — 任务编排是 framework 的事，Workshop 只提供任务状态和看板
+- **不做 SaaS**（目前） — 先解决自己的问题
+- **不替代 Discord** — 社交、社区讨论继续在 Discord
+
+## v0.3 已完成
+
+19 个 PR 全部 merged，复刻并超越了 Discord 上的 agent 自治体系：
+
+- Channel metadata（定位/准则/北极星）
+- Global TODO + per-channel task sections
+- Cron-driven channel autonomy
+- Channel patrol → control room summary
+- Cross-channel notifications
+- Real-time human intervention
+- Kanban view + Cron Dashboard
+- Channel lifecycle（delete/archive/rename）
+- Markdown rendering + agent avatars
+- Agent-to-agent direct messaging
+
+## v0.4 目标
+
+1. **Agent API 设计** — 定义 Workshop Agent Protocol（注册、消息收发、状态上报），参考 Discord Bot API 的成熟模式
+2. **Workshop 平台化** — Server 不直接调 LLM，成为纯 UI + 状态管理 + 平台能力
+3. **OpenClaw adapter** — 作为 reference implementation，让 OpenClaw agent 通过 Agent API 接入 Workshop
+4. **Project 为核心** — 从 channel-centric 切换到 project-centric 组织模式
 
 ## 开发原则
 
 - Claude Code 写所有代码，用 ralph-loop 拆任务
 - 自己做自己测（dogfooding）— Kagura 是第一用户
 - 从 Discord 痛点出发，每个功能都能立刻感受到"比 Discord 好"
+- Workshop 是独立产品，不是 OpenClaw 的附属


### PR DESCRIPTION
Rewrites docs/PRODUCT.md to align with the Luna-confirmed pivot:

- Workshop as independent surface layer (same level as Discord/Slack)
- Agent API as the integration point for any framework  
- Project-centric (not channel-centric) organization
- Three-layer architecture: Surface ← Agent API → Framework
- Updates comparison table with Agent API dimension
- Updates 不做什么 section (now includes framework/orchestrator, removes Agent API)