### PR TITLE
fix: route DMs to OpenClaw gateway so agents can reply

### DIFF
--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -61,7 +61,11 @@ export class Router {
     gw.onTyping = (agentId: string, channelId: string) => {
       const agent = this.agents.get(agentId);
       const agentName = agent?.name ?? agentId;
-      this.broadcast({ type: 'typing', channelId, agentId, agentName });
+      if (channelId.startsWith('dm-')) {
+        this.broadcast({ type: 'dm_typing', agentId, agentName });
+      } else {
+        this.broadcast({ type: 'typing', channelId, agentId, agentName });
+      }
     };
 
     gw.onMessage = (agentId: string, channelId: string, content: string) => {
@@ -71,6 +75,24 @@ export class Router {
       const trimmed = content.trim();
       if (trimmed === 'NO_REPLY' || trimmed === 'HEARTBEAT_OK' || trimmed === 'NO') {
         console.log(`[msg] agent=${agentId} channel=${channelId} silent (${trimmed}), not broadcasting`);
+        return;
+      }
+
+      // DM response handler: if channelId is a DM channel, store as direct message and return
+      if (channelId.startsWith('dm-')) {
+        const agent = this.agents.get(agentId);
+        const senderName = agent?.name ?? agentId;
+        console.log(`[dm] agent=${agentId} replied to DM: "${content.slice(0, 120)}${content.length > 120 ? '...' : ''}"`);
+
+        const db = getDb();
+        const dmId = uuid();
+        const timestamp = new Date().toISOString();
+        db.prepare(
+          'INSERT INTO direct_messages (id, from_id, to_id, content, timestamp, read) VALUES (?, ?, ?, ?, ?, 0)'
+        ).run(dmId, agentId, 'user', content, timestamp);
+
+        const message: DirectMessage = { id: dmId, fromId: agentId, toId: 'user', content, timestamp, read: false };
+        this.broadcast({ type: 'dm_message', message });
         return;
       }
 
@@ -1182,6 +1204,12 @@ export class Router {
 
     const message: DirectMessage = { id, fromId, toId, content, timestamp, read: false };
     this.broadcast({ type: 'dm_message', message });
+
+    // Route to agent via gateway if recipient is a registered agent
+    if (this.agents.has(toId) && this.gateway) {
+      console.log(`[dm] routing user DM to agent=${toId} via gateway channel=dm-${toId}`);
+      this.gateway.sendChat(content, `dm-${toId}`, toId);
+    }
   }
 
   private handleListDms(ws: WebSocket, withId: string, limit?: number, before?: string): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -135,6 +135,7 @@ export type ServerMessage =
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }
+  | { type: 'dm_typing'; agentId: string; agentName: string }
   | { type: 'dm_message'; message: DirectMessage }
   | { type: 'dm_list'; withId: string; messages: DirectMessage[] }
   | { type: 'dm_conversations'; conversations: DmConversation[] }


### PR DESCRIPTION
## Problem

Direct Messages (DMs) to agents were stored in SQLite and broadcast to the UI, but never forwarded to the OpenClaw gateway. This meant agents couldn't see or reply to DMs — only channel messages worked.

## Fix

Three changes in `server/src/router.ts`:

1. **`handleSendDm()`** — After storing the user's DM, forward to the gateway using `gateway.sendChat(content, 'dm-{agentId}', agentId)` when the recipient is a registered agent.

2. **`gw.onMessage` handler** — After the protocol token filter, check if `channelId` starts with `dm-`. If so, store the agent's reply as a `direct_message` (from agent, to user), broadcast `dm_message`, and return early before the channel message path.

3. **`gw.onTyping` handler** — For DM channels, broadcast `dm_typing` instead of the normal channel `typing` event.

Also added `dm_typing` to the `ServerMessage` type union in `types.ts`.

## Testing

- `npx tsc --noEmit` — clean compile ✅
- `npm test` — 106 tests passing (70 server + 36 web), 0 failures ✅