### PR TITLE
feat: remove notification system (#35)

### DIFF
--- a/docs/qa-screenshots/qa-pr40-channel.png
+++ b/docs/qa-screenshots/qa-pr40-channel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33ec9d066705fd8890a026792e3de1844298ff04fd78024acea04d62bfb04bb6
+size 44434

--- a/docs/qa-screenshots/qa-pr40-home.png
+++ b/docs/qa-screenshots/qa-pr40-home.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d41da99b46dabf67bde05e04fe90920e8f5e0b170e1c461fcab2473d57c1ad48
+size 16945

--- a/server/src/__tests__/db.test.ts
+++ b/server/src/__tests__/db.test.ts
@@ -25,7 +25,6 @@ describe('db.ts - Schema initialization', () => {
     expect(names).toContain('north_stars');
     expect(names).toContain('pins');
     expect(names).toContain('patrol_config');
-    expect(names).toContain('notifications');
   });
 
   it('channels table has v0.3 migration columns', () => {
@@ -82,16 +81,4 @@ describe('db.ts - Schema initialization', () => {
     expect(colNames).toContain('require_mention');
   });
 
-  it('notifications has all expected columns', () => {
-    const db = getDb();
-    const cols = db.prepare('PRAGMA table_info(notifications)').all() as { name: string }[];
-    const colNames = cols.map((c) => c.name);
-
-    expect(colNames).toContain('id');
-    expect(colNames).toContain('source_channel_id');
-    expect(colNames).toContain('target_channel_id');
-    expect(colNames).toContain('content');
-    expect(colNames).toContain('trigger_type');
-    expect(colNames).toContain('read');
-  });
 });

--- a/server/src/__tests__/router.test.ts
+++ b/server/src/__tests__/router.test.ts
@@ -115,61 +115,6 @@ describe('router.ts - Core business logic', () => {
     });
   });
 
-  // ------- @notify parsing -------
-  describe('@notify parsing', () => {
-    it('extracts cross-post targets from agent messages', () => {
-      (ctx.router as any).clients.add(ctx.mockWs);
-
-      // parseNotifyCommands matches LOWER(name) — use exact channel name (case-insensitive)
-      // Seed data has channel named 'Other Channel' but LOWER(name) lookup won't match 'other-channel'
-      // Create a channel with a simple single-word name for this test
-      const db = getDb();
-      db.prepare(
-        "INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star) VALUES (?, ?, datetime('now'), 'project', '', '', '')"
-      ).run('deploy', 'deploy');
-
-      const content = '@notify #deploy: heads up, deploy incoming';
-      (ctx.router as any).parseNotifyCommands('test-channel', content);
-
-      const notifs = db.prepare('SELECT * FROM notifications').all() as any[];
-      expect(notifs).toHaveLength(1);
-      expect(notifs[0].source_channel_id).toBe('test-channel');
-      expect(notifs[0].target_channel_id).toBe('deploy');
-      expect(notifs[0].content).toContain('heads up, deploy incoming');
-      expect(notifs[0].trigger_type).toBe('agent_crosspost');
-    });
-
-    it('ignores @notify to the same source channel', () => {
-      (ctx.router as any).clients.add(ctx.mockWs);
-
-      // Use a name that matches the channel name exactly (case-insensitive)
-      // Seed data has channel 'Test Channel' with id 'test-channel'
-      // But LOWER('Test Channel') = 'test channel' ≠ 'test-channel'
-      // So create a channel whose name matches its slug
-      const db = getDb();
-      db.prepare(
-        "INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star) VALUES (?, ?, datetime('now'), 'project', '', '', '')"
-      ).run('selfping', 'selfping');
-
-      const content = '@notify #selfping: self ping';
-      (ctx.router as any).parseNotifyCommands('selfping', content);
-
-      const notifs = db.prepare('SELECT * FROM notifications').all() as any[];
-      expect(notifs).toHaveLength(0);
-    });
-
-    it('ignores @notify to non-existent channels', () => {
-      (ctx.router as any).clients.add(ctx.mockWs);
-
-      const content = '@notify #nonexistent: hello';
-      (ctx.router as any).parseNotifyCommands('test-channel', content);
-
-      const db = getDb();
-      const notifs = db.prepare('SELECT * FROM notifications').all() as any[];
-      expect(notifs).toHaveLength(0);
-    });
-  });
-
   // ------- North Star pin sync -------
   describe('North Star pin sync', () => {
     it('setting a channel-scoped north star auto-creates pin in that channel', () => {
@@ -463,36 +408,6 @@ describe('router.ts - Core business logic', () => {
     });
   });
 
-  // ------- Notification mark read -------
-  describe('Notification mark read', () => {
-    it('marks all unread notifications for a channel as read', () => {
-      (ctx.router as any).clients.add(ctx.mockWs);
-
-      // Create notifications directly
-      const db = getDb();
-      db.prepare(
-        "INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)"
-      ).run('n1', 'test-channel', 'other-channel', 'notif 1', 'agent_crosspost');
-      db.prepare(
-        "INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)"
-      ).run('n2', 'test-channel', 'other-channel', 'notif 2', 'agent_crosspost');
-
-      ctx.clearSent();
-      (ctx.router as any).handleNotificationMarkRead('other-channel');
-
-      const unread = db.prepare("SELECT * FROM notifications WHERE target_channel_id = 'other-channel' AND read = 0").all();
-      expect(unread).toHaveLength(0);
-
-      const allNotifs = db.prepare("SELECT * FROM notifications WHERE target_channel_id = 'other-channel'").all();
-      expect(allNotifs).toHaveLength(2);
-
-      // Should broadcast updated badge
-      const badges = ctx.sentOfType('notification_badge');
-      expect(badges).toHaveLength(1);
-      expect(badges[0].unreadCount).toBe(0);
-    });
-  });
-
   // ------- Channel lifecycle (delete/archive/rename) -------
   describe('Channel lifecycle (delete/archive/rename)', () => {
     it('delete_channel cascades correctly and broadcasts channel_deleted', () => {
@@ -502,8 +417,6 @@ describe('router.ts - Core business logic', () => {
       // Seed related data for test-channel
       db.prepare("INSERT INTO messages (id, channel_id, sender_id, sender_name, role, content, timestamp, is_urgent) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), 0)").run('msg-1', 'test-channel', 'user', 'You', 'user', 'hello');
       db.prepare("INSERT INTO pins (id, channel_id, type, source_id, content, updated_at) VALUES (?, ?, ?, ?, ?, datetime('now'))").run('pin-1', 'test-channel', 'custom', 'src', 'pinned');
-      db.prepare("INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)").run('notif-1', 'test-channel', 'other-channel', 'notif', 'agent_crosspost');
-      db.prepare("INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, datetime('now'), 0)").run('notif-2', 'other-channel', 'test-channel', 'notif2', 'agent_crosspost');
       db.prepare("INSERT INTO cron_executions (id, channel_id, fired_at, agent_ids, prompt_snippet, status) VALUES (?, ?, datetime('now'), ?, ?, ?)").run('exec-1', 'test-channel', '["agent-1"]', 'snippet', 'sent');
       db.prepare("INSERT INTO north_stars (id, scope, content, updated_at) VALUES (?, ?, ?, datetime('now'))").run('ns-1', 'test-channel', 'goal');
 
@@ -517,7 +430,6 @@ describe('router.ts - Core business logic', () => {
       expect(db.prepare('SELECT * FROM channel_agents WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
       expect(db.prepare('SELECT * FROM messages WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
       expect(db.prepare('SELECT * FROM pins WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
-      expect(db.prepare("SELECT * FROM notifications WHERE source_channel_id = 'test-channel' OR target_channel_id = 'test-channel'").all()).toHaveLength(0);
       expect(db.prepare('SELECT * FROM cron_executions WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
       expect(db.prepare("SELECT * FROM north_stars WHERE scope = 'test-channel'").all()).toHaveLength(0);
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -143,21 +143,6 @@ function initSchema(): void {
     );
   `);
 
-  // v0.3 §5: Notifications
-  d.exec(`
-    CREATE TABLE IF NOT EXISTS notifications (
-      id TEXT PRIMARY KEY,
-      source_channel_id TEXT NOT NULL,
-      target_channel_id TEXT NOT NULL,
-      content TEXT NOT NULL,
-      trigger_type TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      read INTEGER NOT NULL DEFAULT 0,
-      FOREIGN KEY (source_channel_id) REFERENCES channels(id),
-      FOREIGN KEY (target_channel_id) REFERENCES channels(id)
-    );
-  `);
-
   // v0.3 §6: Urgent flag on messages
   if (!hasColumn(d, 'messages', 'is_urgent')) {
     d.exec("ALTER TABLE messages ADD COLUMN is_urgent INTEGER NOT NULL DEFAULT 0");

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -4,7 +4,7 @@ import { getDb } from './db.js';
 import { GatewayConnection } from './gateway.js';
 import { ChannelCronManager } from './cron.js';
 import { getPatrolConfig, setPatrolConfig } from './patrol.js';
-import type { ClientMessage, ServerMessage, Message, Channel, Agent, CronExecution, NorthStar, Pin, PatrolConfig, Notification, NotificationTrigger, DirectMessage, DmConversation } from './types.js';
+import type { ClientMessage, ServerMessage, Message, Channel, Agent, CronExecution, NorthStar, Pin, PatrolConfig, DirectMessage, DmConversation } from './types.js';
 
 /**
  * Router — bridges frontend WebSocket clients with a single shared OpenClaw Gateway connection.
@@ -26,7 +26,6 @@ export class Router {
 
     // Send message history for all active channels
     this.sendAllChannelHistory(ws);
-    this.sendAllNotificationBadges(ws);
     this.handlePatrolConfigGet(ws);
     this.sendDmUnread(ws);
 
@@ -79,9 +78,6 @@ export class Router {
 
       const msg = this.storeMessage(channelId, agentId, senderName, 'assistant', content);
       this.broadcast({ type: 'message', channelId, message: msg });
-
-      // Parse @notify cross-posts in agent responses
-      this.parseNotifyCommands(channelId, content);
     };
 
     gw.onStatusChange = (status) => {
@@ -166,9 +162,6 @@ export class Router {
       case 'patrol_trigger':
         this.handlePatrolTrigger();
         break;
-      case 'notification_mark_read':
-        this.handleNotificationMarkRead(msg.channelId);
-        break;
       case 'register_agent':
         this.handleRegisterAgent(ws, msg.agent);
         break;
@@ -252,7 +245,7 @@ export class Router {
     let match: RegExpExecArray | null;
     while ((match = mentionPattern.exec(content)) !== null) {
       const name = match[1].toLowerCase();
-      if (name === 'urgent' || name === 'notify') continue;
+      if (name === 'urgent') continue;
       mentions.add(name);
     }
 
@@ -292,7 +285,6 @@ export class Router {
     db.prepare('DELETE FROM channel_agents WHERE channel_id = ?').run(channelId);
     db.prepare('DELETE FROM messages WHERE channel_id = ?').run(channelId);
     db.prepare('DELETE FROM pins WHERE channel_id = ?').run(channelId);
-    db.prepare('DELETE FROM notifications WHERE source_channel_id = ? OR target_channel_id = ?').run(channelId, channelId);
     db.prepare('DELETE FROM cron_executions WHERE channel_id = ?').run(channelId);
     db.prepare('DELETE FROM north_stars WHERE scope = ?').run(channelId);
 
@@ -773,84 +765,6 @@ export class Router {
     const config = getPatrolConfig();
     if (config) {
       this.broadcast({ type: 'patrol_fired', controlChannelId: config.controlChannelId });
-    }
-  }
-
-  // --- Notification handlers ---
-
-  /** Create and broadcast a notification. */
-  private postNotification(
-    sourceChannelId: string,
-    targetChannelId: string,
-    content: string,
-    trigger: 'agent_crosspost' | 'patrol',
-  ): void {
-    const db = getDb();
-    const id = uuid();
-    const now = new Date().toISOString();
-
-    db.prepare(
-      'INSERT INTO notifications (id, source_channel_id, target_channel_id, content, trigger_type, created_at, read) VALUES (?, ?, ?, ?, ?, ?, 0)'
-    ).run(id, sourceChannelId, targetChannelId, content, trigger, now);
-
-    const notification: Notification = {
-      id, sourceChannelId, targetChannelId, content, trigger,
-      createdAt: now, read: false,
-    };
-
-    this.broadcast({ type: 'notification', notification });
-    this.broadcastNotificationBadge(targetChannelId);
-  }
-
-  private handleNotificationMarkRead(channelId: string): void {
-    const db = getDb();
-    db.prepare('UPDATE notifications SET read = 1 WHERE target_channel_id = ? AND read = 0').run(channelId);
-    this.broadcastNotificationBadge(channelId);
-  }
-
-  private broadcastNotificationBadge(channelId: string): void {
-    const db = getDb();
-    const row = db.prepare(
-      'SELECT COUNT(*) as cnt FROM notifications WHERE target_channel_id = ? AND read = 0'
-    ).get(channelId) as any;
-    this.broadcast({ type: 'notification_badge', channelId, unreadCount: row?.cnt ?? 0 });
-  }
-
-  /** Send notification badges for all channels to a newly connected client. */
-  private sendAllNotificationBadges(ws: WebSocket): void {
-    const db = getDb();
-    const rows = db.prepare(
-      'SELECT target_channel_id, COUNT(*) as cnt FROM notifications WHERE read = 0 GROUP BY target_channel_id'
-    ).all() as any[];
-
-    for (const row of rows) {
-      this.sendTo(ws, { type: 'notification_badge', channelId: row.target_channel_id, unreadCount: row.cnt });
-    }
-  }
-
-  /** Parse @notify #channel-name: message patterns in agent responses. */
-  private parseNotifyCommands(sourceChannelId: string, content: string): void {
-    const pattern = /@notify\s+#([\w-]+):\s*(.+?)(?=@notify\s+#|$)/gs;
-    let match: RegExpExecArray | null;
-
-    while ((match = pattern.exec(content)) !== null) {
-      const targetName = match[1];
-      const notifyContent = match[2].trim();
-
-      const db = getDb();
-      const targetChannel = db.prepare(
-        "SELECT id FROM channels WHERE LOWER(name) = LOWER(?)"
-      ).get(targetName) as any;
-
-      if (!targetChannel) {
-        console.warn(`[notify] target channel not found: #${targetName}`);
-        continue;
-      }
-
-      if (targetChannel.id === sourceChannelId) continue;
-
-      console.log(`[notify] #${sourceChannelId} → #${targetChannel.id}: "${notifyContent.slice(0, 80)}"`);
-      this.postNotification(sourceChannelId, targetChannel.id, notifyContent, 'agent_crosspost');
     }
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -76,7 +76,6 @@ export type ClientMessage =
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
-  | { type: 'notification_mark_read'; channelId: string }
   | { type: 'delete_channel'; channelId: string }
   | { type: 'archive_channel'; channelId: string }
   | { type: 'rename_channel'; channelId: string; name: string }
@@ -106,8 +105,6 @@ export type ServerMessage =
   | { type: 'pin_deleted'; channelId: string; pinId: string }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
-  | { type: 'notification'; notification: Notification }
-  | { type: 'notification_badge'; channelId: string; unreadCount: number }
   | { type: 'channel_deleted'; channelId: string }
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
@@ -151,16 +148,4 @@ export interface PatrolConfig {
   enabled: boolean;
   lastPatrolAt: string | null;
   channelFilter: string[];
-}
-
-export type NotificationTrigger = 'agent_crosspost' | 'patrol';
-
-export interface Notification {
-  id: string;
-  sourceChannelId: string;
-  targetChannelId: string;
-  content: string;
-  trigger: NotificationTrigger;
-  createdAt: string;
-  read: boolean;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,7 +7,7 @@ import { CreateChannelDialog } from './components/CreateChannelDialog';
 import { ChannelSettingsPanel } from './components/ChannelSettingsPanel';
 import { CronDashboard } from './components/CronDashboard';
 import { useWebSocket } from './hooks/useWebSocket';
-import type { Channel, Agent, Message, ServerMessage, Pin, PatrolConfig, Notification, DirectMessage, DmConversation } from './types';
+import type { Channel, Agent, Message, ServerMessage, Pin, PatrolConfig, DirectMessage, DmConversation } from './types';
 
 const WS_URL = `ws://${window.location.hostname}:3100`;
 
@@ -24,8 +24,6 @@ export default function App() {
   const [showCronDashboard, setShowCronDashboard] = useState(false);
   const [pins, setPins] = useState<Record<string, Pin[]>>({});
   const [patrolConfig, setPatrolConfigState] = useState<PatrolConfig | null>(null);
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [notificationBadges, setNotificationBadges] = useState<Record<string, number>>({});
   const [activeView, setActiveView] = useState<ActiveView | null>(null);
   const [dmMessages, setDmMessages] = useState<Record<string, DirectMessage[]>>({});
   const [dmConversations, setDmConversations] = useState<DmConversation[]>([]);
@@ -106,12 +104,6 @@ export default function App() {
       case 'patrol_fired':
         console.log('[patrol] fired for', msg.controlChannelId);
         break;
-      case 'notification':
-        setNotifications((prev) => [...prev, msg.notification]);
-        break;
-      case 'notification_badge':
-        setNotificationBadges((prev) => ({ ...prev, [msg.channelId]: msg.unreadCount }));
-        break;
       case 'agent_registered':
         setAgents((prev) => [...prev, msg.agent]);
         break;
@@ -185,10 +177,6 @@ export default function App() {
     send({ type: 'patrol_trigger' });
   };
 
-  const handleNotificationMarkRead = (channelId: string) => {
-    send({ type: 'notification_mark_read', channelId });
-  };
-
   const handleRegisterAgent = (agent: { id: string; name: string; avatar?: string }) => {
     send({ type: 'register_agent', agent });
   };
@@ -217,9 +205,6 @@ export default function App() {
   useEffect(() => {
     if (activeChannelId && connected) {
       send({ type: 'pin_list', channelId: activeChannelId });
-      if (notificationBadges[activeChannelId] > 0) {
-        send({ type: 'notification_mark_read', channelId: activeChannelId });
-      }
     }
   }, [activeChannelId, connected, send]);
 
@@ -267,7 +252,6 @@ export default function App() {
         channels={channels}
         agents={agents}
         activeChannelId={activeChannelId}
-        notificationBadges={notificationBadges}
         patrolControlChannelId={patrolConfig?.controlChannelId ?? null}
         onSelectChannel={selectChannel}
         onCreateChannel={handleCreateChannel}
@@ -292,7 +276,6 @@ export default function App() {
           channelAgents={channelAgents}
           typingNames={typingNames}
           pins={activeChannelId ? (pins[activeChannelId] || []) : []}
-          notifications={notifications.filter(n => n.targetChannelId === activeChannelId)}
           isPatrolChannel={patrolConfig?.controlChannelId === activeChannelId}
           onSendMessage={handleSendMessage}
           onEditChannel={activeChannel ? handleEditChannel : undefined}

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { MessageContent } from '@/components/MessageContent';
-import type { Agent, Channel, Message, Pin, Notification } from '../types';
+import type { Agent, Channel, Message, Pin } from '../types';
 
 const TYPE_BADGE: Record<string, { label: string; className: string }> = {
   project: { label: 'Project', className: 'bg-discord-accent/20 text-discord-accent' },
@@ -17,7 +17,6 @@ interface ChatViewProps {
   channelAgents: Agent[];
   typingNames: string[];
   pins: Pin[];
-  notifications: Notification[];
   isPatrolChannel: boolean;
   onSendMessage: (content: string) => void;
   onEditChannel?: () => void;
@@ -28,7 +27,7 @@ interface ChatViewProps {
   onPinDelete?: (pinId: string) => void;
 }
 
-export function ChatView({ channel, messages, channelAgents, typingNames, pins, notifications, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onPatrolTrigger, onPinCreate, onPinMessage, onPinDelete }: ChatViewProps) {
+export function ChatView({ channel, messages, channelAgents, typingNames, pins, isPatrolChannel, onSendMessage, onEditChannel, onOpenSettings, onPatrolTrigger, onPinCreate, onPinMessage, onPinDelete }: ChatViewProps) {
   const [input, setInput] = useState('');
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
@@ -343,25 +342,6 @@ export function ChatView({ channel, messages, channelAgents, typingNames, pins, 
             </div>
             );
           })}
-          {notifications.filter(n => !n.read).map((notif) => (
-            <div key={notif.id} className="flex gap-3 py-1 mb-2 border-l-2 border-blue-400 pl-2 bg-blue-400/5 rounded-r">
-              <div className="w-10 h-10 rounded-full flex items-center justify-center text-base font-semibold shrink-0 bg-blue-500 text-white">
-                &#8644;
-              </div>
-              <div className="min-w-0">
-                <div className="flex items-baseline gap-2 mb-0.5">
-                  <span className="font-semibold text-sm text-blue-400">Cross-post</span>
-                  <span className="text-[10px] text-muted-foreground">
-                    from #{notif.sourceChannelId}
-                  </span>
-                  <span className="text-[11px] text-muted-foreground">{formatTime(notif.createdAt)}</span>
-                </div>
-                <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap break-words">
-                  {notif.content}
-                </div>
-              </div>
-            </div>
-          ))}
           <div ref={bottomRef} />
         </div>
       </ScrollArea>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -8,7 +8,6 @@ interface SidebarProps {
   channels: Channel[];
   agents: Agent[];
   activeChannelId: string | null;
-  notificationBadges: Record<string, number>;
   patrolControlChannelId: string | null;
   onSelectChannel: (channelId: string) => void;
   onCreateChannel: (name: string, agents: { id: string; requireMention: boolean }[]) => void;
@@ -19,7 +18,7 @@ interface SidebarProps {
   onSelectDm: (partnerId: string) => void;
 }
 
-export function Sidebar({ channels, agents, activeChannelId, notificationBadges, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard, dmUnread, activeDmPartnerId, onSelectDm }: SidebarProps) {
+export function Sidebar({ channels, agents, activeChannelId, patrolControlChannelId, onSelectChannel, onCreateChannel, onOpenSettings, onOpenCronDashboard, dmUnread, activeDmPartnerId, onSelectDm }: SidebarProps) {
   const [showDialog, setShowDialog] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
 
@@ -66,11 +65,6 @@ export function Sidebar({ channels, agents, activeChannelId, notificationBadges,
               <span className="flex-1 truncate">{channel.name}</span>
               {channel.id === patrolControlChannelId && (
                 <span className="shrink-0 text-yellow-400/80 text-[11px]" title="Patrol control channel">&#128737;</span>
-              )}
-              {(notificationBadges[channel.id] ?? 0) > 0 && (
-                <span className="shrink-0 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold leading-none px-1">
-                  {notificationBadges[channel.id]}
-                </span>
               )}
               {channel.cronEnabled && (
                 <span className="shrink-0 text-muted-foreground/60 text-[11px]" title="Cron enabled">&#128339;</span>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -96,8 +96,6 @@ export type ServerMessage =
   | { type: 'pin_deleted'; channelId: string; pinId: string }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
-  | { type: 'notification'; notification: Notification }
-  | { type: 'notification_badge'; channelId: string; unreadCount: number }
   | { type: 'channel_deleted'; channelId: string }
   | { type: 'agent_registered'; agent: Agent }
   | { type: 'agent_updated'; agent: Agent }
@@ -127,7 +125,6 @@ export type ClientMessage =
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
-  | { type: 'notification_mark_read'; channelId: string }
   | { type: 'delete_channel'; channelId: string }
   | { type: 'archive_channel'; channelId: string }
   | { type: 'rename_channel'; channelId: string; name: string }
@@ -158,15 +155,3 @@ export interface PatrolConfig {
   channelFilter: string[];
 }
 
-export type NotificationTrigger = 'todo_change' | 'agent_crosspost' | 'patrol';
-
-export interface Notification {
-  id: string;
-  sourceChannelId: string;
-  targetChannelId: string;
-  content: string;
-  trigger: NotificationTrigger;
-  todoItemId: string | null;
-  createdAt: string;
-  read: boolean;
-}


### PR DESCRIPTION
Part of #35 (Strip to MVP) — Subtask 2

Removes the entire Notification system: cross-post notifications, badges, mark-read, @notify parsing.

**Removed (9 files, -281 lines):**
- Notification types from web + server
- All notification state/handlers from App.tsx
- Cross-post notification rendering from ChatView.tsx
- Notification badge from Sidebar.tsx
- 5 server handlers (postNotification, handleNotificationMarkRead, broadcastNotificationBadge, sendAllNotificationBadges, parseNotifyCommands)
- notifications table from DB schema
- All notification test blocks

**Tests:** 53 server + 36 web = 89 all pass.