### PR TITLE
feat: remove north star system (#35)

### DIFF
--- a/docs/qa-screenshots/qa-pr43-channel.png
+++ b/docs/qa-screenshots/qa-pr43-channel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2f1c92177cc4eabeee350988e3d79050885777eb50367059468b78babf62f6
+size 43665

--- a/docs/qa-screenshots/qa-pr43-home.png
+++ b/docs/qa-screenshots/qa-pr43-home.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d41da99b46dabf67bde05e04fe90920e8f5e0b170e1c461fcab2473d57c1ad48
+size 16945

--- a/server/src/__tests__/db.test.ts
+++ b/server/src/__tests__/db.test.ts
@@ -22,7 +22,6 @@ describe('db.ts - Schema initialization', () => {
     expect(names).toContain('channel_agents');
     expect(names).toContain('messages');
     expect(names).toContain('cron_executions');
-    expect(names).toContain('north_stars');
     expect(names).toContain('patrol_config');
   });
 
@@ -34,7 +33,6 @@ describe('db.ts - Schema initialization', () => {
     expect(colNames).toContain('type');
     expect(colNames).toContain('positioning');
     expect(colNames).toContain('guidelines');
-    expect(colNames).toContain('north_star');
     expect(colNames).toContain('cron_schedule');
     expect(colNames).toContain('cron_enabled');
   });

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -49,12 +49,12 @@ export function seedTestData(db: ReturnType<typeof getDb>) {
   );
 
   db.prepare(
-    'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-  ).run('test-channel', 'Test Channel', new Date().toISOString(), 'project', 'test positioning', 'test guidelines', '', null, 0);
+    'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run('test-channel', 'Test Channel', new Date().toISOString(), 'project', 'test positioning', 'test guidelines', null, 0);
 
   db.prepare(
-    'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-  ).run('other-channel', 'Other Channel', new Date().toISOString(), 'daily', '', '', '', null, 0);
+    'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run('other-channel', 'Other Channel', new Date().toISOString(), 'daily', '', '', null, 0);
 
   // agent-1 sees all, agent-2 requires mention
   db.prepare('INSERT INTO channel_agents (channel_id, agent_id, require_mention) VALUES (?, ?, ?)').run(

--- a/server/src/__tests__/patrol.test.ts
+++ b/server/src/__tests__/patrol.test.ts
@@ -8,7 +8,7 @@ describe('patrol.ts - Patrol config', () => {
     // Patrol config requires a channel to exist for the FK
     const db = getDb();
     db.prepare(
-      "INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star) VALUES (?, ?, datetime('now'), 'meta', '', '', '')"
+      "INSERT INTO channels (id, name, created_at, type, positioning, guidelines) VALUES (?, ?, datetime('now'), 'meta', '', '')"
     ).run('control-channel', 'Control');
   });
 

--- a/server/src/__tests__/router.test.ts
+++ b/server/src/__tests__/router.test.ts
@@ -379,7 +379,6 @@ describe('router.ts - Core business logic', () => {
       // Seed related data for test-channel
       db.prepare("INSERT INTO messages (id, channel_id, sender_id, sender_name, role, content, timestamp, is_urgent) VALUES (?, ?, ?, ?, ?, ?, datetime('now'), 0)").run('msg-1', 'test-channel', 'user', 'You', 'user', 'hello');
       db.prepare("INSERT INTO cron_executions (id, channel_id, fired_at, agent_ids, prompt_snippet, status) VALUES (?, ?, datetime('now'), ?, ?, ?)").run('exec-1', 'test-channel', '["agent-1"]', 'snippet', 'sent');
-      db.prepare("INSERT INTO north_stars (id, scope, content, updated_at) VALUES (?, ?, ?, datetime('now'))").run('ns-1', 'test-channel', 'goal');
 
       ctx.clearSent();
       (ctx.router as any).handleDeleteChannel('test-channel');
@@ -391,7 +390,6 @@ describe('router.ts - Core business logic', () => {
       expect(db.prepare('SELECT * FROM channel_agents WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
       expect(db.prepare('SELECT * FROM messages WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
       expect(db.prepare('SELECT * FROM cron_executions WHERE channel_id = ?').all('test-channel')).toHaveLength(0);
-      expect(db.prepare("SELECT * FROM north_stars WHERE scope = 'test-channel'").all()).toHaveLength(0);
 
       // Broadcast
       const deleted = ctx.sentOfType('channel_deleted');

--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -69,7 +69,6 @@ export class ChannelCronManager {
       type: row.type ?? 'project',
       positioning: row.positioning ?? '',
       guidelines: row.guidelines ?? '',
-      northStar: row.north_star ?? '',
       cronSchedule: row.cron_schedule ?? null,
       cronEnabled: !!row.cron_enabled,
     };
@@ -93,7 +92,6 @@ export class ChannelCronManager {
     ];
 
     if (channel.positioning) parts.push(`\nChannel purpose: ${channel.positioning}`);
-    if (channel.northStar) parts.push(`North star: ${channel.northStar}`);
     if (channel.guidelines) parts.push(`\nGuidelines:\n${channel.guidelines}`);
     if (messageContext) parts.push(messageContext);
 
@@ -201,7 +199,6 @@ export class ChannelCronManager {
         type: row.type ?? 'project',
         positioning: row.positioning ?? '',
         guidelines: row.guidelines ?? '',
-        northStar: row.north_star ?? '',
         cronSchedule: row.cron_schedule ?? null,
         cronEnabled: !!row.cron_enabled,
       };

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -91,7 +91,6 @@ function initSchema(): void {
     ['type', "ALTER TABLE channels ADD COLUMN type TEXT NOT NULL DEFAULT 'project'"],
     ['positioning', "ALTER TABLE channels ADD COLUMN positioning TEXT NOT NULL DEFAULT ''"],
     ['guidelines', "ALTER TABLE channels ADD COLUMN guidelines TEXT NOT NULL DEFAULT ''"],
-    ['north_star', "ALTER TABLE channels ADD COLUMN north_star TEXT NOT NULL DEFAULT ''"],
     ['cron_schedule', 'ALTER TABLE channels ADD COLUMN cron_schedule TEXT'],
     ['cron_enabled', 'ALTER TABLE channels ADD COLUMN cron_enabled INTEGER NOT NULL DEFAULT 0'],
   ];
@@ -110,13 +109,6 @@ function initSchema(): void {
       prompt_snippet TEXT,
       status TEXT NOT NULL DEFAULT 'sent',
       FOREIGN KEY (channel_id) REFERENCES channels(id)
-    );
-
-    CREATE TABLE IF NOT EXISTS north_stars (
-      id TEXT PRIMARY KEY,
-      scope TEXT NOT NULL DEFAULT 'global',
-      content TEXT NOT NULL,
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
   `);

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -4,7 +4,7 @@ import { getDb } from './db.js';
 import { GatewayConnection } from './gateway.js';
 import { ChannelCronManager } from './cron.js';
 import { getPatrolConfig, setPatrolConfig } from './patrol.js';
-import type { ClientMessage, ServerMessage, Message, Channel, Agent, CronExecution, NorthStar, PatrolConfig } from './types.js';
+import type { ClientMessage, ServerMessage, Message, Channel, Agent, CronExecution, PatrolConfig } from './types.js';
 
 /**
  * Router — bridges frontend WebSocket clients with a single shared OpenClaw Gateway connection.
@@ -22,7 +22,6 @@ export class Router {
     // Immediately send current channels and agents so the UI populates on load
     this.handleListChannels(ws);
     this.handleListAgents(ws);
-    this.handleNorthStarGet(ws); // send all north stars
 
     // Send message history for all active channels
     this.sendAllChannelHistory(ws);
@@ -133,12 +132,6 @@ export class Router {
         break;
       case 'cron_history':
         this.handleCronHistory(ws, msg.channelId);
-        break;
-      case 'north_star_get':
-        this.handleNorthStarGet(ws, msg.scope);
-        break;
-      case 'north_star_set':
-        this.handleNorthStarSet(msg.scope, msg.content);
         break;
       case 'patrol_config_get':
         this.handlePatrolConfigGet(ws);
@@ -260,7 +253,6 @@ export class Router {
     db.prepare('DELETE FROM channel_agents WHERE channel_id = ?').run(channelId);
     db.prepare('DELETE FROM messages WHERE channel_id = ?').run(channelId);
     db.prepare('DELETE FROM cron_executions WHERE channel_id = ?').run(channelId);
-    db.prepare('DELETE FROM north_stars WHERE scope = ?').run(channelId);
 
     // Stop cron
     if (this.cronManager) {
@@ -299,7 +291,7 @@ export class Router {
           agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
           createdAt: updated.created_at, status: updated.status,
           type: updated.type ?? 'project', positioning: updated.positioning ?? '',
-          guidelines: updated.guidelines ?? '', northStar: updated.north_star ?? '',
+          guidelines: updated.guidelines ?? '',
           cronSchedule: updated.cron_schedule ?? null,
           cronEnabled: !!updated.cron_enabled,
         };
@@ -318,7 +310,7 @@ export class Router {
       agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
       createdAt: updated.created_at, status: updated.status,
       type: updated.type ?? 'project', positioning: updated.positioning ?? '',
-      guidelines: updated.guidelines ?? '', northStar: updated.north_star ?? '',
+      guidelines: updated.guidelines ?? '',
       cronSchedule: updated.cron_schedule ?? null,
       cronEnabled: !!updated.cron_enabled,
     };
@@ -343,7 +335,7 @@ export class Router {
       agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
       createdAt: row.created_at, status: row.status,
       type: row.type ?? 'project', positioning: row.positioning ?? '',
-      guidelines: row.guidelines ?? '', northStar: row.north_star ?? '',
+      guidelines: row.guidelines ?? '',
       cronSchedule: row.cron_schedule ?? null,
       cronEnabled: !!row.cron_enabled,
     };
@@ -368,7 +360,6 @@ export class Router {
         type: r.type ?? 'project',
         positioning: r.positioning ?? '',
         guidelines: r.guidelines ?? '',
-        northStar: r.north_star ?? '',
         cronSchedule: r.cron_schedule ?? null,
         cronEnabled: !!r.cron_enabled,
       };
@@ -392,7 +383,7 @@ export class Router {
     _ws: WebSocket,
     name: string,
     agents: { id: string; requireMention: boolean }[],
-    metadata?: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>>,
+    metadata?: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>>,
   ): void {
     const db = getDb();
     const id = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
@@ -401,13 +392,12 @@ export class Router {
     const channelType = metadata?.type ?? 'project';
     const positioning = metadata?.positioning ?? '';
     const guidelines = metadata?.guidelines ?? '';
-    const northStar = metadata?.northStar ?? '';
     const cronSchedule = metadata?.cronSchedule ?? null;
     const cronEnabled = metadata?.cronEnabled ? 1 : 0;
 
     db.prepare(
-      'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, north_star, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
-    ).run(id, name, now, channelType, positioning, guidelines, northStar, cronSchedule, cronEnabled);
+      'INSERT INTO channels (id, name, created_at, type, positioning, guidelines, cron_schedule, cron_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, name, now, channelType, positioning, guidelines, cronSchedule, cronEnabled);
 
     for (const agent of agents) {
       db.prepare(
@@ -419,7 +409,7 @@ export class Router {
     const agentConfigs = agents.map(a => ({ id: a.id, requireMention: a.requireMention }));
     const channel: Channel = {
       id, name, agents: agentIds, agentConfigs, createdAt: now, status: 'active',
-      type: channelType, positioning, guidelines, northStar, cronSchedule,
+      type: channelType, positioning, guidelines, cronSchedule,
       cronEnabled: !!cronEnabled,
     };
     this.broadcast({ type: 'channel_created', channel });
@@ -447,7 +437,6 @@ export class Router {
     const channel: Channel = {
       id: row.id, name: row.name, agents: agentIds, agentConfigs, createdAt: row.created_at, status: row.status,
       type: row.type ?? 'project', positioning: row.positioning ?? '', guidelines: row.guidelines ?? '',
-      northStar: row.north_star ?? '',
       cronSchedule: row.cron_schedule ?? null, cronEnabled: !!row.cron_enabled,
     };
     this.broadcast({ type: 'channel_updated', channel });
@@ -455,7 +444,7 @@ export class Router {
 
   private handleUpdateChannelMeta(
     channelId: string,
-    metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>>,
+    metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>>,
   ): void {
     const db = getDb();
     const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as any;
@@ -467,7 +456,6 @@ export class Router {
     if (metadata.type !== undefined) { updates.push('type = ?'); values.push(metadata.type); }
     if (metadata.positioning !== undefined) { updates.push('positioning = ?'); values.push(metadata.positioning); }
     if (metadata.guidelines !== undefined) { updates.push('guidelines = ?'); values.push(metadata.guidelines); }
-    if (metadata.northStar !== undefined) { updates.push('north_star = ?'); values.push(metadata.northStar); }
     if (metadata.cronSchedule !== undefined) { updates.push('cron_schedule = ?'); values.push(metadata.cronSchedule); }
     if (metadata.cronEnabled !== undefined) { updates.push('cron_enabled = ?'); values.push(metadata.cronEnabled ? 1 : 0); }
 
@@ -488,7 +476,7 @@ export class Router {
       agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
       createdAt: updated.created_at, status: updated.status,
       type: updated.type ?? 'project', positioning: updated.positioning ?? '',
-      guidelines: updated.guidelines ?? '', northStar: updated.north_star ?? '',
+      guidelines: updated.guidelines ?? '',
       cronSchedule: updated.cron_schedule ?? null,
       cronEnabled: !!updated.cron_enabled,
     };
@@ -498,47 +486,6 @@ export class Router {
     if (this.cronManager && (metadata.cronSchedule !== undefined || metadata.cronEnabled !== undefined)) {
       this.cronManager.syncChannel(channel);
     }
-  }
-
-  // --- North Star handlers ---
-
-  private handleNorthStarGet(ws: WebSocket, scope?: string): void {
-    const db = getDb();
-    if (scope) {
-      const row = db.prepare('SELECT * FROM north_stars WHERE scope = ?').get(scope) as any;
-      if (row) {
-        this.sendTo(ws, { type: 'north_star', star: this.mapNorthStarRow(row) });
-      } else {
-        // Return empty star for the requested scope
-        this.sendTo(ws, { type: 'north_star', star: { id: '', scope, content: '', updatedAt: '' } });
-      }
-    } else {
-      const rows = db.prepare('SELECT * FROM north_stars ORDER BY updated_at DESC').all() as any[];
-      const stars: NorthStar[] = rows.map(this.mapNorthStarRow);
-      this.sendTo(ws, { type: 'north_star_list', stars });
-    }
-  }
-
-  private handleNorthStarSet(scope: string, content: string): void {
-    const db = getDb();
-    const existing = db.prepare('SELECT * FROM north_stars WHERE scope = ?').get(scope) as any;
-    const now = new Date().toISOString();
-
-    let star: NorthStar;
-    if (existing) {
-      db.prepare('UPDATE north_stars SET content = ?, updated_at = ? WHERE scope = ?').run(content, now, scope);
-      star = { id: existing.id, scope, content, updatedAt: now };
-    } else {
-      const id = uuid();
-      db.prepare('INSERT INTO north_stars (id, scope, content, updated_at) VALUES (?, ?, ?, ?)').run(id, scope, content, now);
-      star = { id, scope, content, updatedAt: now };
-    }
-
-    this.broadcast({ type: 'north_star', star });
-  }
-
-  private mapNorthStarRow(r: any): NorthStar {
-    return { id: r.id, scope: r.scope, content: r.content, updatedAt: r.updated_at };
   }
 
   // --- Cron handlers ---
@@ -730,7 +677,7 @@ export class Router {
         agentConfigs: agents.map(a => ({ id: a.agent_id, requireMention: !!a.require_mention })),
         createdAt: row.created_at, status: row.status,
         type: row.type ?? 'project', positioning: row.positioning ?? '',
-        guidelines: row.guidelines ?? '', northStar: row.north_star ?? '',
+        guidelines: row.guidelines ?? '',
         cronSchedule: row.cron_schedule ?? null,
         cronEnabled: !!row.cron_enabled,
       };

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -23,7 +23,6 @@ export interface Channel {
   type: ChannelType;
   positioning: string;
   guidelines: string;
-  northStar: string;
   cronSchedule: string | null;
   cronEnabled: boolean;
 }
@@ -43,15 +42,13 @@ export interface Message {
 export type ClientMessage =
   | { type: 'send_message'; channelId: string; content: string }
   | { type: 'join_channel'; channelId: string }
-  | { type: 'create_channel'; name: string; agents: { id: string; requireMention: boolean }[]; metadata?: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>> }
+  | { type: 'create_channel'; name: string; agents: { id: string; requireMention: boolean }[]; metadata?: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>> }
   | { type: 'update_channel'; channelId: string; agents: { id: string; requireMention: boolean }[] }
-  | { type: 'update_channel_meta'; channelId: string; metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>> }
+  | { type: 'update_channel_meta'; channelId: string; metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>> }
   | { type: 'list_channels' }
   | { type: 'list_agents' }
   | { type: 'cron_trigger'; channelId: string }
   | { type: 'cron_history'; channelId: string }
-  | { type: 'north_star_get'; scope?: string }
-  | { type: 'north_star_set'; scope: string; content: string }
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }
@@ -73,8 +70,6 @@ export type ServerMessage =
   | { type: 'channel_meta_updated'; channel: Channel }
   | { type: 'cron_fired'; channelId: string; execution: CronExecution }
   | { type: 'cron_history'; channelId: string; executions: CronExecution[] }
-  | { type: 'north_star'; star: NorthStar }
-  | { type: 'north_star_list'; stars: NorthStar[] }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'channel_deleted'; channelId: string }
@@ -82,13 +77,6 @@ export type ServerMessage =
   | { type: 'agent_updated'; agent: Agent }
   | { type: 'agent_removed'; id: string }
   | { type: 'error'; message: string };
-
-export interface NorthStar {
-  id: string;
-  scope: 'global' | string;  // 'global' or channel ID
-  content: string;
-  updatedAt: string;
-}
 
 export interface CronExecution {
   id: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,7 +107,7 @@ export default function App() {
     send({ type: 'update_channel', channelId, agents: agentConfigs });
   };
 
-  const handleUpdateChannelMeta = (channelId: string, metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>>) => {
+  const handleUpdateChannelMeta = (channelId: string, metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>>) => {
     send({ type: 'update_channel_meta', channelId, metadata });
   };
 

--- a/web/src/components/ChannelSettingsPanel.tsx
+++ b/web/src/components/ChannelSettingsPanel.tsx
@@ -10,7 +10,7 @@ interface ChannelSettingsPanelProps {
   patrolConfig: PatrolConfig | null;
   channels: Channel[];
   onClose: () => void;
-  onSave: (metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>>) => void;
+  onSave: (metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>>) => void;
   onCronTrigger?: (channelId: string) => void;
   cronHistory?: CronExecution[];
   onPatrolConfigSave?: (config: Partial<PatrolConfig>) => void;
@@ -29,7 +29,6 @@ export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose,
   const [type, setType] = useState<ChannelType>(channel.type);
   const [positioning, setPositioning] = useState(channel.positioning);
   const [guidelines, setGuidelines] = useState(channel.guidelines);
-  const [northStar, setNorthStar] = useState(channel.northStar);
   const [cronSchedule, setCronSchedule] = useState(channel.cronSchedule ?? '');
   const [cronEnabled, setCronEnabled] = useState(channel.cronEnabled);
   const [renameName, setRenameName] = useState(channel.name);
@@ -47,7 +46,6 @@ export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose,
       type,
       positioning,
       guidelines,
-      northStar,
       cronSchedule: cronSchedule || null,
       cronEnabled,
     });
@@ -103,16 +101,6 @@ export function ChannelSettingsPanel({ channel, patrolConfig, channels, onClose,
               onChange={(e) => setGuidelines(e.target.value)}
               placeholder="Rules and guidelines for agents in this channel"
               className="w-full py-2 px-3 rounded-md bg-muted text-foreground text-sm border border-border resize-none min-h-[80px] placeholder:text-muted-foreground/60 outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label className="text-xs uppercase tracking-wide text-muted-foreground">North Star</Label>
-            <Input
-              value={northStar}
-              onChange={(e) => setNorthStar(e.target.value)}
-              placeholder="The overarching goal for this channel"
-              className="bg-muted text-sm"
             />
           </div>
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -18,7 +18,6 @@ export interface Channel {
   type: ChannelType;
   positioning: string;
   guidelines: string;
-  northStar: string;
   cronSchedule: string | null;
   cronEnabled: boolean;
 }
@@ -30,13 +29,6 @@ export interface CronExecution {
   agentIds: string[];
   promptSnippet: string;
   status: string;
-}
-
-export interface NorthStar {
-  id: string;
-  scope: 'global' | string;
-  content: string;
-  updatedAt: string;
 }
 
 export interface Message {
@@ -61,8 +53,6 @@ export type ServerMessage =
   | { type: 'channel_meta_updated'; channel: Channel }
   | { type: 'cron_fired'; channelId: string; execution: CronExecution }
   | { type: 'cron_history'; channelId: string; executions: CronExecution[] }
-  | { type: 'north_star'; star: NorthStar }
-  | { type: 'north_star_list'; stars: NorthStar[] }
   | { type: 'patrol_config'; config: PatrolConfig | null }
   | { type: 'patrol_fired'; controlChannelId: string }
   | { type: 'channel_deleted'; channelId: string }
@@ -76,13 +66,11 @@ export type ClientMessage =
   | { type: 'send_message'; channelId: string; content: string }
   | { type: 'create_channel'; name: string; agents: { id: string; requireMention: boolean }[] }
   | { type: 'update_channel'; channelId: string; agents: { id: string; requireMention: boolean }[] }
-  | { type: 'update_channel_meta'; channelId: string; metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'northStar' | 'cronSchedule' | 'cronEnabled'>> }
+  | { type: 'update_channel_meta'; channelId: string; metadata: Partial<Pick<Channel, 'type' | 'positioning' | 'guidelines' | 'cronSchedule' | 'cronEnabled'>> }
   | { type: 'list_channels' }
   | { type: 'list_agents' }
   | { type: 'cron_trigger'; channelId: string }
   | { type: 'cron_history'; channelId: string }
-  | { type: 'north_star_get'; scope?: string }
-  | { type: 'north_star_set'; scope: string; content: string }
   | { type: 'patrol_config_get' }
   | { type: 'patrol_config_set'; config: Partial<PatrolConfig> }
   | { type: 'patrol_trigger' }


### PR DESCRIPTION
Part of #35 (Strip to MVP) — Subtask 5

Removes the North Star system (goal setting per channel/global).

**Cleaned (11 files, -125 lines):**
- router.ts — handleNorthStarGet/Set, switch cases, north_star in channel CRUD
- db.ts — north_stars table + north_star column from channels
- cron.ts — northStar from channel mapping + prompt assembly
- types.ts (web + server) — NorthStar type, northStar on Channel, message variants
- ChannelSettingsPanel.tsx — northStar display
- App.tsx — northStar state
- Tests/helpers — north star blocks and seed data

**Tests:** 28 web + 37 server = 65 all pass. Web build clean.