### PR TITLE
fix: deduplicate messages on reconnect (#31)

### DIFF
--- a/docs/qa-screenshots/qa-pr47-after-send.png
+++ b/docs/qa-screenshots/qa-pr47-after-send.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c5f64399c5a052d9809f3fad325740f4adae0dbfe1d2cc6e2d3d1e0bd13515
+size 33689

--- a/docs/qa-screenshots/qa-pr47-after-switch.png
+++ b/docs/qa-screenshots/qa-pr47-after-switch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c5f64399c5a052d9809f3fad325740f4adae0dbfe1d2cc6e2d3d1e0bd13515
+size 33689

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -470,19 +470,17 @@ export class Router {
         'SELECT * FROM messages WHERE channel_id = ? ORDER BY timestamp ASC LIMIT 200'
       ).all(channelId) as any[];
 
-      for (const r of rows) {
-        const msg: Message = {
-          id: r.id,
-          channelId: r.channel_id,
-          senderId: r.sender_id,
-          senderName: r.sender_name,
-          role: r.role,
-          content: r.content,
-          timestamp: r.timestamp,
-          isUrgent: !!r.is_urgent,
-        };
-        this.sendTo(ws, { type: 'message', channelId, message: msg });
-      }
+      const msgs: Message[] = rows.map((r) => ({
+        id: r.id,
+        channelId: r.channel_id,
+        senderId: r.sender_id,
+        senderName: r.sender_name,
+        role: r.role,
+        content: r.content,
+        timestamp: r.timestamp,
+        isUrgent: !!r.is_urgent,
+      }));
+      this.sendTo(ws, { type: 'channel_history', channelId, messages: msgs });
     }
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -54,6 +54,7 @@ export type ClientMessage =
 // WebSocket protocol: server → client
 export type ServerMessage =
   | { type: 'message'; channelId: string; message: Message }
+  | { type: 'channel_history'; channelId: string; messages: Message[] }
   | { type: 'typing'; channelId: string; agentId: string; agentName: string }
   | { type: 'channel_list'; channels: Channel[] }
   | { type: 'agent_list'; agents: Agent[] }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,11 +40,15 @@ export default function App() {
           });
         }, 30000);
         break;
+      case 'channel_history':
+        setMessages((prev) => ({ ...prev, [msg.channelId]: msg.messages }));
+        break;
       case 'message':
-        setMessages((prev) => ({
-          ...prev,
-          [msg.channelId]: [...(prev[msg.channelId] || []), msg.message],
-        }));
+        setMessages((prev) => {
+          const existing = prev[msg.channelId] || [];
+          if (existing.some((m) => m.id === msg.message.id)) return prev;
+          return { ...prev, [msg.channelId]: [...existing, msg.message] };
+        });
         // Clear typing for this agent when their message arrives
         if (msg.message.role === 'assistant') {
           setTyping((prev) => {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -36,6 +36,7 @@ export interface Message {
 // Messages from server
 export type ServerMessage =
   | { type: 'message'; channelId: string; message: Message }
+  | { type: 'channel_history'; channelId: string; messages: Message[] }
   | { type: 'typing'; channelId: string; agentId: string; agentName: string }
   | { type: 'channel_list'; channels: Channel[] }
   | { type: 'agent_list'; agents: Agent[] }


### PR DESCRIPTION
Fixes #31

**Problem:** Switching channels or WebSocket reconnect causes messages to duplicate. `sendAllChannelHistory()` sent history as individual `type: 'message'` events — same as real-time messages. Frontend appended every event without dedup.

**Fix:**
- Server sends history as batch `channel_history` event (one per channel) instead of individual `message` events
- Frontend handles `channel_history` by replacing (not appending) channel messages
- Added dedup safety net on the `message` handler: skips if message id already exists

**4 files changed. Tests: 28 web + 28 server = 56 all pass. Web build clean.**